### PR TITLE
Mixed integer ops

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -3,8 +3,10 @@ name: CI
 on:
   push:
     branches:
-      - main
+      - "*"
   pull_request:
+    branches:
+      - main
     types: [opened, synchronize, reopened]
   workflow_dispatch:
 

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -20,6 +20,7 @@ args = ["clippy", "--all-features"]
 [tasks.docs]
 args = ["doc", "--no-deps", "--all-features"]
 
+# Build package in no_std environment.
 [tasks.no-std]
 command = "cargo"
 args = ["build", "--target", "thumbv7m-none-eabi"]
@@ -54,6 +55,11 @@ run_task = "chkall"
 [tasks.cov8]
 env = { "RUSTFLAGS" = "--cfg=cnst8bitonly" }
 run_task = "coverage-tarpaulin"
+
+# Linter check with 8bit types only.
+[tasks.clp8]
+env = { "RUSTFLAGS" = "--cfg=cnst8bitonly" }
+run_task = "clippy"
 
 # Run all 8bit related unit tests.
 [tasks.t8]
@@ -129,3 +135,7 @@ args = [
     "i128",
     "isize",
 ]
+
+# Run all 8bit related doc examples only.
+[tasks.td8]
+run_task = { name = ["tdu8", "tdi8"] }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -94,16 +94,13 @@ mod macros;
 // Format:
 //  { uint, sint, uint_mod, sint_mod, TypeName, ErrorName, MinErrorName, MaxErrorName },+
 //
-// Builds `u8` only, which is significantly faster. Useful for most development
-// purposes.
-#[cfg(cnst8bitonly)]
+// Building 8bit related types exclusively is faster, useful for most development purposes.
+#[cfg(any(cnst8bitonly, not(cnst8bitonly)))]
 constrained_uint_def_impl! {
     { u8, i8, u8, i8, ConstrainedU8, ConstrainedU8Error, MinU8Error, MaxU8Error }
 }
-// Builds all unsigned types by default.
 #[cfg(not(cnst8bitonly))]
 constrained_uint_def_impl! {
-    { u8, i8, u8, i8, ConstrainedU8, ConstrainedU8Error, MinU8Error, MaxU8Error },
     { u16, i16, u16, i16, ConstrainedU16, ConstrainedU16Error, MinU16Error, MaxU16Error },
     { u32, i32, u32, i32, ConstrainedU32, ConstrainedU32Error, MinU32Error, MaxU32Error },
     { u64, i64, u64, i64, ConstrainedU64, ConstrainedU64Error, MinU64Error, Max64Error },
@@ -117,19 +114,19 @@ constrained_uint_def_impl! {
 // Format:
 //  { sint, uint, sint_mod, uint_mod, TypeName, ErrorName, MinErrorName, MaxErrorName },+
 //
-// Builds `i8` only, which is significantly faster. Useful for most development
-// purposes.
-#[cfg(cnst8bitonly)]
+// Building 8bit related types exclusively is faster, useful for most development purposes.
+#[cfg(any(cnst8bitonly, not(cnst8bitonly)))]
 constrained_int_def_impl! {
     { i8, u8, i8, u8, ConstrainedI8, ConstrainedI8Error, MinI8Error, MaxI8Error },
 }
-// Builds all signed types by default.
 #[cfg(not(cnst8bitonly))]
 constrained_int_def_impl! {
-    { i8, u8, i8, u8, ConstrainedI8, ConstrainedI8Error, MinI8Error, MaxI8Error },
     { i16, u16, i16, u16, ConstrainedI16, ConstrainedI16Error, MinI16Error, MaxI16Error },
     { i32, u32, i32, u32, ConstrainedI32, ConstrainedI32Error, MinI32Error, MaxI32Error },
     { i64, u64, i64, u64, ConstrainedI64, ConstrainedI64Error, MinI64Error, MaxI64Error },
     { i128, u128, i128, u128, ConstrainedI128, ConstrainedI128Error, MinI128Error, MaxI128Error },
     { isize, usize, isize, usize, ConstrainedIsize, ConstrainedIsizeError, MinIsizeError, MaxIsizeError },
 }
+
+#[cfg(test)]
+mod proptest;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -71,6 +71,10 @@
 #![allow(incomplete_features)]
 #![feature(generic_const_exprs)]
 //
+// Tracking issue for `mixed_integer_ops`:
+// https://github.com/rust-lang/rust/issues/87840.
+#![feature(mixed_integer_ops)]
+//
 // Tracking issue for `doc_auto_cfg` feature:
 // https://github.com/rust-lang/rust/issues/43781.
 #![feature(doc_auto_cfg)]
@@ -88,23 +92,23 @@ mod macros;
 // default values for doc examples.
 //
 // Format:
-//  { uint, uint_mod, TypeName, ErrorName, MinErrorName, MaxErrorName },+
+//  { uint, sint, uint_mod, sint_mod, TypeName, ErrorName, MinErrorName, MaxErrorName },+
 //
 // Builds `u8` only, which is significantly faster. Useful for most development
 // purposes.
 #[cfg(cnst8bitonly)]
 constrained_uint_def_impl! {
-    { u8, u8, ConstrainedU8, ConstrainedU8Error, MinU8Error, MaxU8Error }
+    { u8, i8, u8, i8, ConstrainedU8, ConstrainedU8Error, MinU8Error, MaxU8Error }
 }
 // Builds all unsigned types by default.
 #[cfg(not(cnst8bitonly))]
 constrained_uint_def_impl! {
-    { u8, u8, ConstrainedU8, ConstrainedU8Error, MinU8Error, MaxU8Error },
-    { u16, u16, ConstrainedU16, ConstrainedU16Error, MinU16Error, MaxU16Error },
-    { u32, u32, ConstrainedU32, ConstrainedU32Error, MinU32Error, MaxU32Error },
-    { u64, u64, ConstrainedU64, ConstrainedU64Error, MinU64Error, Max64Error },
-    { u128, u128, ConstrainedU128, ConstrainedU128Error, Min128Error, Max128Error },
-    { usize, usize, ConstrainedUsize, ConstrainedUsizeError, MinUsizeError, MaxUsizeError },
+    { u8, i8, u8, i8, ConstrainedU8, ConstrainedU8Error, MinU8Error, MaxU8Error },
+    { u16, i16, u16, i16, ConstrainedU16, ConstrainedU16Error, MinU16Error, MaxU16Error },
+    { u32, i32, u32, i32, ConstrainedU32, ConstrainedU32Error, MinU32Error, MaxU32Error },
+    { u64, i64, u64, i64, ConstrainedU64, ConstrainedU64Error, MinU64Error, Max64Error },
+    { u128, i128, u128, i128, ConstrainedU128, ConstrainedU128Error, Min128Error, Max128Error },
+    { usize, isize, usize, isize, ConstrainedUsize, ConstrainedUsizeError, MinUsizeError, MaxUsizeError },
 }
 
 // Define mods, containers, errors, tests and impls for signed integers with

--- a/src/macros/common.rs
+++ b/src/macros/common.rs
@@ -1,8 +1,8 @@
 // Defines containers, errors, common impls and doc values for integers.
 macro_rules! constrained_def_impl {
-    ($Int:ty, $md:ident, $Ty:ident, $Err:ident, $MinErr:ident, $MaxErr:ident,
-        $min:literal..=$max:literal, ($l:literal, $h:literal)) =>
-    {
+    (   $Int:ty, $md:ident, $Ty:ident, $Err:ident, $MinErr:ident, $MaxErr:ident,
+        $min:literal..=$max:literal, ($l:literal, $h:literal)
+    ) => {
         // This const function is used to enforce constraints for the range definition.
         // Relevant const generics are: `MIN`, `MAX`.
         // The constraints are:
@@ -417,6 +417,15 @@ macro_rules! constrained_def_impl {
             #[inline(always)]
             pub const fn get(&self) -> $Int {
                 self.0
+            }
+
+            /// **Not** part of the public API, implementation detail.
+            // Unfortunate workaround.
+            // Issue: https://github.com/Mari-W/const_guards/issues/2.
+            #[doc(hidden)]
+            #[cfg(test)]
+            pub const fn __new(value: $Int) -> Result<Self, $Err<MIN, MAX>> {
+                Self::new_unguarded(value)
             }
         }
 

--- a/src/macros/mod.rs
+++ b/src/macros/mod.rs
@@ -11,9 +11,3 @@ mod uint;
 // Requires `constrained_def_impl!` macro.
 #[macro_use]
 mod int;
-
-// Import `cnst_gen_def_impl!` macro.
-// Import `rhs_gen_def_impl!` macro.
-#[cfg(test)]
-#[macro_use]
-mod proptest;

--- a/src/proptest/macros.rs
+++ b/src/proptest/macros.rs
@@ -1,26 +1,26 @@
 // Defines and implements `CnstGen`, used for `proptest` integration.
 #[cfg(test)]
 macro_rules! cnst_gen_def_impl {
-    ($Int:ty, $int_md:ident, $mod_name:ident, $ty_path:path, $Ty:ident) => {
+    ($Int:ty, $int_md:ident, $Ty:ident, $mod_name:ident, $Gen:ident) => {
         #[cfg(test)]
         mod $mod_name {
             use ::core::ops::RangeInclusive;
             use ::proptest::num::$int_md::BinarySearch;
             use ::proptest::strategy::{NewTree, Strategy, ValueTree};
             use ::proptest::test_runner::TestRunner;
-            use $ty_path::*;
+            use crate::$int_md::*;
 
             /// `CnstGen` is a `Constrained` type generator.
-            // TODO: visibilty should be pub(super) or pub(crate).
+            // TODO: visibilty should be `pub(crate)`.
             #[derive(Clone, Copy, Debug)]
-            pub struct CnstGen<const MIN: $Int, const MAX: $Int, const DEF: $Int>;
+            pub struct $Gen<const MIN: $Int, const MAX: $Int, const DEF: $Int>;
 
-            impl<const MIN: $Int, const MAX: $Int, const DEF: $Int> CnstGen<MIN, MAX, DEF> {
+            impl<const MIN: $Int, const MAX: $Int, const DEF: $Int> $Gen<MIN, MAX, DEF> {
                 const RANGE: RangeInclusive<$Int> = MIN..=MAX;
             }
 
             impl<const MIN: $Int, const MAX: $Int, const DEF: $Int> Strategy
-                for CnstGen<MIN, MAX, DEF>
+                for $Gen<MIN, MAX, DEF>
             {
                 type Value = $Ty<MIN, MAX, DEF>;
                 type Tree = CnstBinarySearch<MIN, MAX, DEF>;
@@ -30,7 +30,7 @@ macro_rules! cnst_gen_def_impl {
                 }
             }
 
-            // TODO: visibilty should be private.
+            // TODO: visibilty should be `pub(crate)`.
             #[derive(Clone, Copy, Debug)]
             pub struct CnstBinarySearch<const MIN: $Int, const MAX: $Int, const DEF: $Int>(
                 BinarySearch,
@@ -42,7 +42,7 @@ macro_rules! cnst_gen_def_impl {
                 type Value = $Ty<MIN, MAX, DEF>;
 
                 fn current(&self) -> Self::Value {
-                    $Ty::<MIN, MAX, DEF>::new_unguarded(self.0.current()).unwrap()
+                    $Ty::<MIN, MAX, DEF>::__new(self.0.current()).unwrap()
                 }
 
                 fn simplify(&mut self) -> bool {
@@ -60,25 +60,25 @@ macro_rules! cnst_gen_def_impl {
 // Defines and implements `RhsGen` and `Rhs`, used for `proptest` integration.
 #[cfg(test)]
 macro_rules! rhs_gen_def_impl {
-    ($({ $Int:ty, $int_md:ident, $mod_name:ident }),+ $(,)*) => {$(
+    ($Int:ty, $int_md:ident, $mod_name:ident, $Gen:ident, $Rhs:ident) => {
         #[cfg(test)]
         mod $mod_name {
             use ::core::ops::{Add, RangeInclusive, Sub};
+            use ::proptest::num::$int_md::BinarySearch;
             use ::proptest::strategy::{NewTree, Strategy, ValueTree};
             use ::proptest::test_runner::TestRunner;
-            use ::proptest::num::$int_md::BinarySearch;
 
-            /// `RhsGen` is a `Rhs` type generator.
-            // TODO: visibilty should be pub(super) or pub(crate).
+            /// `$Gen` is a `Rhs` type generator.
+            // TODO: visibilty should be `pub(crate)`.
             #[derive(Clone, Copy, Debug)]
-            pub struct RhsGen<const S: $Int, const E: $Int>;
+            pub struct $Gen<const S: $Int, const E: $Int>;
 
-            impl<const S: $Int, const E: $Int> RhsGen<S, E> {
+            impl<const S: $Int, const E: $Int> $Gen<S, E> {
                 const RANGE: RangeInclusive<$Int> = S..=E;
             }
 
-            impl<const S: $Int, const E: $Int> Strategy for RhsGen<S, E> {
-                type Value = Rhs<S, E>;
+            impl<const S: $Int, const E: $Int> Strategy for $Gen<S, E> {
+                type Value = $Rhs<S, E>;
                 type Tree = RhsBinarySearch<S, E>;
 
                 fn new_tree(&self, runner: &mut TestRunner) -> NewTree<Self> {
@@ -86,15 +86,15 @@ macro_rules! rhs_gen_def_impl {
                 }
             }
 
-            // TODO: visibilty should be private.
+            // TODO: visibilty should be `pub(crate)`.
             #[derive(Clone, Copy, Debug)]
             pub struct RhsBinarySearch<const S: $Int, const E: $Int>(BinarySearch);
 
             impl<const S: $Int, const E: $Int> ValueTree for RhsBinarySearch<S, E> {
-                type Value = Rhs<S, E>;
+                type Value = $Rhs<S, E>;
 
                 fn current(&self) -> Self::Value {
-                    Rhs::try_from(self.0.current()).unwrap()
+                    $Rhs::try_from(self.0.current()).unwrap()
                 }
 
                 fn simplify(&mut self) -> bool {
@@ -107,40 +107,40 @@ macro_rules! rhs_gen_def_impl {
             }
 
             /// `Rhs` is a bounded `rhs` for arithmetics operations.
-            // TODO: visibilty should be pub(super) or pub(crate).
+            // TODO: visibilty should be `pub(crate)`.
             #[derive(Clone, Copy, Debug)]
-            pub struct Rhs<const S: $Int, const E: $Int>($Int);
+            pub struct $Rhs<const S: $Int, const E: $Int>($Int);
 
-            impl<const S: $Int, const E: $Int> Rhs<S, E> {
-                // TODO: visibilty should be pub(super) or pub(crate).
+            impl<const S: $Int, const E: $Int> $Rhs<S, E> {
+                // TODO: visibilty should be `pub(crate)`.
                 #[must_use]
                 #[inline(always)]
-                pub fn get(self) -> $Int {
+                pub const fn get(self) -> $Int {
                     self.0
                 }
             }
 
-            impl<const S: $Int, const E: $Int> Add<Rhs<S, E>> for $Int {
+            impl<const S: $Int, const E: $Int> Add<$Rhs<S, E>> for $Int {
                 type Output = $Int;
 
                 #[must_use]
                 #[inline(always)]
-                fn add(self, rhs: Rhs<S, E>) -> Self::Output {
+                fn add(self, rhs: $Rhs<S, E>) -> Self::Output {
                     self + rhs.0
                 }
             }
 
-            impl<const S: $Int, const E: $Int> Sub<Rhs<S, E>> for $Int {
+            impl<const S: $Int, const E: $Int> Sub<$Rhs<S, E>> for $Int {
                 type Output = $Int;
 
                 #[must_use]
                 #[inline(always)]
-                fn sub(self, rhs: Rhs<S, E>) -> Self::Output {
+                fn sub(self, rhs: $Rhs<S, E>) -> Self::Output {
                     self - rhs.0
                 }
             }
 
-            impl<const S: $Int, const E: $Int> Sub<$Int> for Rhs<S, E> {
+            impl<const S: $Int, const E: $Int> Sub<$Int> for $Rhs<S, E> {
                 type Output = $Int;
 
                 #[must_use]
@@ -150,7 +150,7 @@ macro_rules! rhs_gen_def_impl {
                 }
             }
 
-            impl<const S: $Int, const E: $Int> TryFrom<$Int> for Rhs<S, E> {
+            impl<const S: $Int, const E: $Int> TryFrom<$Int> for $Rhs<S, E> {
                 type Error = &'static str;
 
                 fn try_from(num: $Int) -> Result<Self, Self::Error> {
@@ -159,6 +159,65 @@ macro_rules! rhs_gen_def_impl {
                     } else {
                         Err("value is not contained within Rhs's range")
                     }
+                }
+            }
+        }
+    };
+}
+
+// Defines and implemets strategies for unsigned types.
+#[cfg(test)]
+macro_rules! strategies_uint_def_impl {
+    ($({ $UnsInt:ty, $uint_md:ident, $Ty:ident }),+ $(,)*) => {$(
+        #[cfg(test)]
+        // TODO: visibility should be `pub(crate)`.
+        pub mod $uint_md {
+            cnst_gen_def_impl! {
+                $UnsInt, $uint_md, $Ty, cnst, CnstGen
+            }
+            // TODO: visibility should be `pub(crate)`.
+            pub use cnst::*;
+
+            rhs_gen_def_impl! {
+                $UnsInt, $uint_md, rhs, RhsGen, Rhs
+            }
+            // TODO: visibility should be `pub(crate)`.
+            pub use rhs::*;
+        }
+    )+};
+}
+
+// Defines and implemets strategies for signed types.
+#[cfg(test)]
+macro_rules! strategies_int_def_impl {
+    ($({ $SigInt:ty, $UnsInt:ty, $sint_md:ident, $Ty:ident }),+ $(,)*) => {$(
+        #[cfg(test)]
+        // TODO: visibility should be `pub(crate)`.
+        pub mod $sint_md {
+            cnst_gen_def_impl! {
+                $SigInt, $sint_md, $Ty, cnst, CnstGen
+            }
+            // TODO: visibility should be `pub(crate)`.
+            pub use cnst::*;
+
+            rhs_gen_def_impl! {
+                $SigInt, $sint_md, rhs, RhsGen, Rhs
+            }
+            // TODO: visibility should be `pub(crate)`.
+            pub use rhs::*;
+
+            impl<const S: $SigInt, const E: $SigInt> Rhs<S, E> {
+                // TODO: visibility should be `pub(crate)`.
+                pub const fn unsigned(self) -> $UnsInt {
+                    self.get() as $UnsInt
+                }
+            }
+
+            impl<const S: $SigInt, const E: $SigInt> ::core::ops::Neg for Rhs<S, E> {
+                type Output = $SigInt;
+
+                fn neg(self) -> Self::Output {
+                    -self.get()
                 }
             }
         }

--- a/src/proptest/mod.rs
+++ b/src/proptest/mod.rs
@@ -1,5 +1,6 @@
 // Import `strategies_uint_def_impl!` macro.
 // Import `strategies_int_def_impl!` macro.
+#[cfg(test)]
 #[macro_use]
 mod macros;
 

--- a/src/proptest/mod.rs
+++ b/src/proptest/mod.rs
@@ -1,0 +1,30 @@
+// Import `strategies_uint_def_impl!` macro.
+// Import `strategies_int_def_impl!` macro.
+#[macro_use]
+mod macros;
+
+#[cfg(any(cnst8bitonly, not(cnst8bitonly)))]
+strategies_uint_def_impl! {
+    { u8, u8, ConstrainedU8 }
+}
+#[cfg(not(cnst8bitonly))]
+strategies_uint_def_impl! {
+    { u16, u16, ConstrainedU16 },
+    { u32, u32, ConstrainedU32 },
+    { u64, u64, ConstrainedU64 },
+    { u128, u128, ConstrainedU128 },
+    { usize, usize, ConstrainedUsize },
+}
+
+#[cfg(any(cnst8bitonly, not(cnst8bitonly)))]
+strategies_int_def_impl! {
+    { i8, u8, i8, ConstrainedI8 }
+}
+#[cfg(not(cnst8bitonly))]
+strategies_int_def_impl! {
+    { i16, u16, i16, ConstrainedI16 },
+    { i32, u32, i32, ConstrainedI32 },
+    { i64, u64, i64, ConstrainedI64 },
+    { i128, u128, i128, ConstrainedI128 },
+    { isize, usize, isize, ConstrainedIsize },
+}


### PR DESCRIPTION
Implement mixed arithmetic operations for `Constrained` types.
Pairing with the [feature](https://github.com/rust-lang/rust/issues/87840): `#![feature(mixed_integer_ops)]`.

```rust
// `uX` means: `u8`, `u16`, `u32`, `u64`, `u128` and `usize`.
// `iX` means: `i8`, `i16`, `i32`, `i64`, `i128` and `isize`.

impl<const MIN: uX, const MAX: uX, const DEF: uX> ConstrainedUX<MIN, MAX, DEF> {
    pub const fn checked_add_signed(self, value: iX) -> Option<Self>;
    pub const fn overflowing_add_signed(self, iX) -> (Self, bool);
    pub const fn saturating_add_signed(self, iX) -> Self;
    pub const fn wrapping_add_signed(self, iX) -> Self;
    pub const fn try_add_signed(self, iX) -> Result<Self, ConstrainedUXError>;
}

impl<const MIN: iX, const MAX: iX, const DEF: iX> ConstrainedIX<MIN, MAX, DEF> {
    pub const fn checked_add_unsigned(self, uX) -> Option<Self>;
    pub const fn overflowing_add_unsigned(self, uX) -> (Self, bool);
    pub const fn saturating_add_unsigned(self, uX) -> Self;
    pub const fn wrapping_add_unsigned(self, uX) -> Self;
    pub const fn try_add_unsigned(self, uX) -> Result<Self, MaxIXError>;

    pub const fn checked_sub_unsigned(self, uX) -> Option<Self>;
    pub const fn overflowing_sub_unsigned(self, uX) -> (Self, bool);
    pub const fn saturating_sub_unsigned(self, uX) -> Self;
    pub const fn wrapping_sub_unsigned(self, uX) -> Self;
    pub const fn try_sub_unsigned(self, uX) -> Result<Self, MinIXError>;
}
```