### PR TITLE
Serde integration

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -131,15 +131,6 @@ jobs:
 
       - name: Run cargo tarpaulin
         uses: actions-rs/tarpaulin@v0.1
-        with:
-          # tarpaulin is reporting uncovered
-          # documentation code in src/lib.rs
-          # for some reason.
-          args: >
-            --all-features
-            --ignore-tests
-            --exclude-files src/lib.rs
-            --out Xml
 
       - name: Upload coverage report
         uses: codecov/codecov-action@v3

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -40,6 +40,13 @@ jobs:
   linter:
     name: Linter
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        include:
+          - features: "--no-default-features"
+          - features: "--features std"
+          - features: "--features serde"
+          - features: "--all-features"
 
     steps:
       - name: Install nightly toolchain
@@ -60,7 +67,7 @@ jobs:
         uses: actions-rs/clippy-check@v1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          args: --all-features -- -D warnings
+          args: ${{ matrix.features }} -- -D warnings
 
   docs:
     name: Documentation
@@ -86,37 +93,6 @@ jobs:
         with:
           command: doc
           args: --all-features
-
-  checks:
-    name: Check
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        include:
-          - features: "--no-default-features"
-          - features: "--features std"
-          - features: "--features serde"
-          - features: "--all-features"
-
-    steps:
-      - name: Install nightly toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: ${{ env.RUST_CHANNEL }}
-          profile: minimal
-          override: true
-
-      - name: Checkout repository
-        uses: actions/checkout@v2
-
-      - name: Check build cache
-        uses: Swatinem/rust-cache@v1
-
-      - name: Run cargo test
-        uses: actions-rs/cargo@v1
-        with:
-          command: check
-          args: ${{ matrix.features }}
 
   coverage:
     name: Coverage
@@ -171,8 +147,8 @@ jobs:
         with:
           command: check
           args: >
-            --target thumbv7m-none-eabi
             ${{ matrix.features }}
+            --target thumbv7m-none-eabi
 
   public:
     name: Public changes

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -87,9 +87,16 @@ jobs:
           command: doc
           args: --all-features
 
-  tests:
-    name: Tests
+  checks:
+    name: Check
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        include:
+          - features: "--no-default-features"
+          - features: "--features std"
+          - features: "--features serde"
+          - features: "--all-features"
 
     steps:
       - name: Install nightly toolchain
@@ -108,8 +115,8 @@ jobs:
       - name: Run cargo test
         uses: actions-rs/cargo@v1
         with:
-          command: test
-          args: --all-features
+          command: check
+          args: ${{ matrix.features }}
 
   coverage:
     name: Coverage
@@ -138,6 +145,11 @@ jobs:
   no_std:
     name: No std
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        include:
+          - features: "--no-default-features"
+          - features: "--features serde"
 
     steps:
       - name: Install nightly toolchain
@@ -154,11 +166,13 @@ jobs:
       - name: Check build cache
         uses: Swatinem/rust-cache@v1
 
-      - name: Run cargo build
+      - name: Run cargo check
         uses: actions-rs/cargo@v1
         with:
-          command: build
-          args: --target thumbv7m-none-eabi
+          command: check
+          args: >
+            --target thumbv7m-none-eabi
+            ${{ matrix.features }}
 
   public:
     name: Public changes
@@ -170,7 +184,7 @@ jobs:
       - name: Install nightly toolchain
         uses: actions-rs/toolchain@v1
         with:
-          # cargo-pulic-api will only build report if it finds
+          # cargo-pulic-api will only build reports if it finds
           # `nightly-x86_64-unknown-linux-gnu` specifically.
           toolchain: nightly
           profile: minimal

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 todo.txt
 cobertura.xml
 /proptest-regressions
+/semver-checks

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,3 +35,7 @@ all-features = true
 [[test]]
 name = "deserialize"
 required-features = ["serde"]
+
+[[test]]
+name = "deserialize_error"
+required-features = ["serde"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,14 +14,16 @@ authors = ["Pedro de Matos Fedricci <pedromfedricci@gmail.com>"]
 categories = ["no-std", "mathematics", "algorithms"]
 keywords = ["no_std", "numerics"]
 
-exclude = [".github", "ci"]
+exclude = [".github", "ci", "Makefile.toml", "codecov.yaml"]
 
 [features]
-# This will import std as a dependency.
+# This will import `std` as a dependency.
 std = []
+serde = ["dep:serde"]
 
 [dependencies]
 const_guards = { version = "0.1.3" }
+serde = { version = "1", default-features = false, optional = true }
 
 [dev-dependencies]
 proptest = { version = "1" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,11 @@ serde = { version = "1", default-features = false, optional = true }
 
 [dev-dependencies]
 proptest = { version = "1" }
+serde_test = { version = "1" }
 
 [package.metadata.docs.rs]
 all-features = true
+
+[[test]]
+name = "deserialize"
+required-features = ["serde"]

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -31,15 +31,7 @@ script = { file = "ci/report_public_api.sh" }
 
 [tasks.coverage-tarpaulin.linux]
 command = "cargo"
-args = [
-    "tarpaulin",
-    "--out",
-    "Xml",
-    "--all-features",
-    "--ignore-tests",
-    "--exclude-files",
-    "src/lib.rs",
-]
+args = ["tarpaulin", "--config", "tarpaulin.toml"]
 
 # Check package with all types.
 [tasks.chkall]

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -57,7 +57,7 @@ run_task = "clippy"
 [tasks.t8]
 env = { "RUSTFLAGS" = "--cfg=cnst8bitonly" }
 command = "cargo"
-args = ["test", "--all-features", "--lib"]
+args = ["test", "--all-features", "--tests"]
 
 # Run `u8` related unit tests only.
 [tasks.tu8]

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -44,7 +44,7 @@ args = [
 # Check package with all types.
 [tasks.chkall]
 command = "cargo"
-args = ["check", "--all-features", "--tests"]
+args = ["check", "--all-features"]
 
 # Check package with 8bit types only.
 [tasks.chk8]

--- a/README.md
+++ b/README.md
@@ -76,6 +76,11 @@ This project documentation is hosted at [docs.rs][doc-link].
 
 ## Feature flags
 
+This crate does not provide any default features. The features that can be
+enabled are: `std` and `serde`.
+
+### std
+
 This crate does not link against the standard library by default, so it is
 suitable for `no_std` environments. It does provide a `std` feature though,
 that enables the standard library as a dependency. By enabling this crate's
@@ -86,12 +91,17 @@ that enables the standard library as a dependency. By enabling this crate's
 If users already are importing the standard library on their crate, enabling
 `std` feature comes at no additional cost.
 
+### serde
+
+The `serde` feature implements [serde]'s `Serialize` and `Deserialize` traits
+for all `Constrained` types.
+
 ## License
 
 Licensed under either of
 
-- Apache License, Version 2.0 ([LICENSE-APACHE](LICENSE-APACHE) or <http://apache.org/licenses/LICENSE-2.0>)
-- MIT license ([LICENSE-MIT](LICENSE-MIT) or <http://opensource.org/licenses/MIT>)
+- Apache License, Version 2.0 ([LICENSE-APACHE] or <http://apache.org/licenses/LICENSE-2.0>)
+- MIT license ([LICENSE-MIT] or <http://opensource.org/licenses/MIT>)
 
 ## Contribution
 
@@ -108,11 +118,14 @@ each of your dependencies, including this one.
 
 [const_guards]: https://docs.rs/const_guards/latest/const_guards/
 [generic_const_exprs]: https://github.com/rust-lang/rust/issues/76560
+[serde]: https://serde.rs/
 [cargo-crev]: https://github.com/crev-dev/cargo-crev
 [doc-link]: https://docs.rs/constrained_int
 [crate-link]: https://crates.io/crates/constrained_int
 [codecov-link]: https://codecov.io/gh/pedromfedricci/constrained_int
 [ci-link]: https://github.com/pedromfedricci/constrained_int/actions/workflows/ci.yaml
+[LICENSE-APACHE]: ./LICENSE-APACHE
+[LICENSE-MIT]: ./LICENSE-MIT
 
 [//]: # (badges)
 

--- a/src/deserialize/macros.rs
+++ b/src/deserialize/macros.rs
@@ -126,6 +126,7 @@ macro_rules! int_to_uint {
 
 // Casts a 128bit visitor to inner's (128bit) type, if representable. Then constructs the
 // container if the range definiton is valid, and the value is within range.
+#[cfg(not(cnst8bitonly))]
 macro_rules! num_128 {
     ($Inner:ty, $Visit:ty : $visit:ident) => {
         fn $visit<E: DesError>(self, v: $Visit) -> Result<Self::Value, E> {

--- a/src/deserialize/macros.rs
+++ b/src/deserialize/macros.rs
@@ -28,7 +28,9 @@ macro_rules! constrained_deserialize_impl {
                         if guard_construction::<MIN, MAX, DEF>() {
                             Ok(())
                         } else {
-                            Err(E::invalid_type(Unexpected::Other("invalid range definition"), self))
+                            Err(E::invalid_type(Unexpected::Other(
+                                concat!(stringify!($Cnst), "<MIN, MAX, DEF>")),
+                                self))
                         }
                     }
                 }
@@ -39,7 +41,11 @@ macro_rules! constrained_deserialize_impl {
                     type Value = crate::$num_mod::$Cnst<MIN, MAX, DEF>;
 
                     fn expecting(&self, f: &mut Formatter<'_>) -> FmtResult {
-                        write!(f, "a constrained {} value within {MIN}..={MAX}", stringify!($Num))
+                        if !guard_construction::<MIN, MAX, DEF>() {
+                            write!(f, "MIN, MAX and DEF to comply with construction constraints")
+                        } else {
+                            write!(f, "a constrained {} value within {MIN}..={MAX}", stringify!($Num))
+                        }
                     }
 
                     $($($method!($Inner, $Visit : $visit);)*)*

--- a/src/deserialize/macros.rs
+++ b/src/deserialize/macros.rs
@@ -1,0 +1,115 @@
+macro_rules! constrained_deserialize_impl {
+    ($Int:ty, $int_md:ident, $Ty:ident, $deserialize:ident, $($method:ident!($Inner:ty, $($Arg:ty : $visit:ident)*);)*) => {
+        #[cfg(feature = "serde")]
+        impl<'de, const MIN: $Int, const MAX: $Int, const DEF: $Int> ::serde::Deserialize<'de>
+            for crate::$int_md::$Ty<MIN, MAX, DEF>
+        {
+            fn deserialize<D: ::serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+                use ::serde::de::{Error as DesError, Visitor, Unexpected};
+                use ::core::fmt::{Formatter, Result as FmtResult};
+                // use crate::$int_md::guard_construction;
+
+                struct ConstrainedVisitor<const MIN: $Int, const MAX: $Int, const DEF: $Int>;
+
+                // TODO: reuse modules's guard instead.
+                // Unfortunate workaround.
+                // Issue: https://github.com/Mari-W/const_guards/issues/2.
+                #[inline(always)]
+                const fn guard_construction<const MIN: $Int, const MAX: $Int, const DEF: $Int>() -> bool {
+                    (MIN < MAX) && (DEF >= MIN && DEF <= MAX)  && (MIN > <$Int>::MIN || MAX < <$Int>::MAX)
+                }
+
+                impl<const MIN: $Int, const MAX: $Int, const DEF: $Int> ConstrainedVisitor<MIN, MAX, DEF> {
+                    fn guard_construction<E: DesError>(&self) -> Result<(), E> {
+                        if guard_construction::<MIN, MAX, DEF>() {
+                            Ok(())
+                        } else {
+                            Err(E::invalid_type(Unexpected::Other("invalid range definition"), self))
+                        }
+                    }
+                }
+
+                impl<const MIN: $Int, const MAX: $Int, const DEF: $Int> Visitor<'_>
+                    for ConstrainedVisitor<MIN, MAX, DEF>
+                {
+                    type Value = crate::$int_md::$Ty<MIN, MAX, DEF>;
+
+                    fn expecting(&self, f: &mut Formatter<'_>) -> FmtResult {
+                        write!(f, "a constrained {} value within {MIN}..={MAX}", stringify!($Int))
+                    }
+
+                    $($($method!($Inner, $Arg : $visit);)*)*
+                }
+
+                deserializer.$deserialize(ConstrainedVisitor)
+            }
+        }
+    };
+}
+
+// Equivalent to serde's `num_self!` and `num_as_self!` but for uint only.
+macro_rules! num_as_self_uint {
+    ($UnsInt:ty, $Arg:ty : $visit:ident) => {
+        fn $visit<E: DesError>(self, v: $Arg) -> Result<Self::Value, E> {
+            self.guard_construction()?;
+            Self::Value::__new(v as $UnsInt)
+                .map_err(|_| E::invalid_value(Unexpected::Unsigned(v as u64), &self))
+        }
+    };
+}
+
+// Equivalent to serde's `num_self!` and `num_as_self!` but for sint only.
+macro_rules! num_as_self_int {
+    ($SigInt:ty, $Arg:ty : $visit:ident) => {
+        fn $visit<E: DesError>(self, v: $Arg) -> Result<Self::Value, E> {
+            self.guard_construction()?;
+            Self::Value::__new(v as $SigInt)
+                .map_err(|_| E::invalid_value(Unexpected::Signed(v as i64), &self))
+        }
+    };
+}
+
+macro_rules! uint_to_self {
+    ($UnsInt:ty, $Arg:ty : $visit:ident) => {
+        fn $visit<E: DesError>(self, v: $Arg) -> Result<Self::Value, E> {
+            self.guard_construction()?;
+
+            if v as u64 <= <$UnsInt>::MAX as u64 {
+                if let Ok(value) = Self::Value::__new(v as $UnsInt) {
+                    return Ok(value);
+                }
+            }
+            Err(E::invalid_value(Unexpected::Unsigned(v as u64), &self))
+        }
+    };
+}
+
+macro_rules! int_to_int {
+    ($SigInt:ty, $Arg:ty : $visit:ident) => {
+        fn $visit<E: DesError>(self, v: $Arg) -> Result<Self::Value, E> {
+            self.guard_construction()?;
+
+            if <$SigInt>::MIN as i64 <= v as i64 && v as i64 <= <$SigInt>::MAX as i64 {
+                if let Ok(value) = Self::Value::__new(v as $SigInt) {
+                    return Ok(value);
+                }
+            }
+            Err(E::invalid_value(Unexpected::Signed(v as i64), &self))
+        }
+    };
+}
+
+macro_rules! int_to_uint {
+    ($UnsInt:ty, $Arg:ty : $visit:ident) => {
+        fn $visit<E: DesError>(self, v: $Arg) -> Result<Self::Value, E> {
+            self.guard_construction()?;
+
+            if 0 < v && v as u64 <= <$UnsInt>::MAX as u64 {
+                Self::Value::__new(v as $UnsInt)
+                    .map_err(|_| E::invalid_value(Unexpected::Unsigned(v as u64), &self))
+            } else {
+                Err(E::invalid_value(Unexpected::Signed(v as i64), &self))
+            }
+        }
+    };
+}

--- a/src/deserialize/macros.rs
+++ b/src/deserialize/macros.rs
@@ -114,7 +114,7 @@ macro_rules! int_to_uint {
         fn $visit<E: DesError>(self, v: $SigInt) -> Result<Self::Value, E> {
             self.guard_construction()?;
 
-            if 0 < v && v as u64 <= <$UnsInner>::MAX as u64 {
+            if 0 <= v && v as u64 <= <$UnsInner>::MAX as u64 {
                 if let Ok(value) = Self::Value::__new(v as $UnsInner) {
                     return Ok(value);
                 }

--- a/src/deserialize/macros.rs
+++ b/src/deserialize/macros.rs
@@ -1,25 +1,25 @@
 macro_rules! constrained_deserialize_impl {
-    ($Int:ty, $int_md:ident, $Ty:ident, $deserialize:ident, $($method:ident!($Inner:ty, $($Arg:ty : $visit:ident)*);)*) => {
+    ($Num:ty, $num_mod:ident, $Cnst:ident, $deserialize:ident, $($method:ident!($Inner:ty, $($Visit:ty : $visit:ident)*);)*) => {
         #[cfg(feature = "serde")]
-        impl<'de, const MIN: $Int, const MAX: $Int, const DEF: $Int> ::serde::Deserialize<'de>
-            for crate::$int_md::$Ty<MIN, MAX, DEF>
+        impl<'de, const MIN: $Num, const MAX: $Num, const DEF: $Num> ::serde::Deserialize<'de>
+            for crate::$num_mod::$Cnst<MIN, MAX, DEF>
         {
             fn deserialize<D: ::serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
                 use ::serde::de::{Error as DesError, Visitor, Unexpected};
                 use ::core::fmt::{Formatter, Result as FmtResult};
-                // use crate::$int_md::guard_construction;
+                // use crate::$num_mod::guard_construction;
 
-                struct ConstrainedVisitor<const MIN: $Int, const MAX: $Int, const DEF: $Int>;
+                struct ConstrainedVisitor<const MIN: $Num, const MAX: $Num, const DEF: $Num>;
 
                 // TODO: reuse modules's guard instead.
                 // Unfortunate workaround.
                 // Issue: https://github.com/Mari-W/const_guards/issues/2.
                 #[inline(always)]
-                const fn guard_construction<const MIN: $Int, const MAX: $Int, const DEF: $Int>() -> bool {
-                    (MIN < MAX) && (DEF >= MIN && DEF <= MAX)  && (MIN > <$Int>::MIN || MAX < <$Int>::MAX)
+                const fn guard_construction<const MIN: $Num, const MAX: $Num, const DEF: $Num>() -> bool {
+                    (MIN < MAX) && (DEF >= MIN && DEF <= MAX)  && (MIN > <$Num>::MIN || MAX < <$Num>::MAX)
                 }
 
-                impl<const MIN: $Int, const MAX: $Int, const DEF: $Int> ConstrainedVisitor<MIN, MAX, DEF> {
+                impl<const MIN: $Num, const MAX: $Num, const DEF: $Num> ConstrainedVisitor<MIN, MAX, DEF> {
                     fn guard_construction<E: DesError>(&self) -> Result<(), E> {
                         if guard_construction::<MIN, MAX, DEF>() {
                             Ok(())
@@ -29,16 +29,16 @@ macro_rules! constrained_deserialize_impl {
                     }
                 }
 
-                impl<const MIN: $Int, const MAX: $Int, const DEF: $Int> Visitor<'_>
+                impl<const MIN: $Num, const MAX: $Num, const DEF: $Num> Visitor<'_>
                     for ConstrainedVisitor<MIN, MAX, DEF>
                 {
-                    type Value = crate::$int_md::$Ty<MIN, MAX, DEF>;
+                    type Value = crate::$num_mod::$Cnst<MIN, MAX, DEF>;
 
                     fn expecting(&self, f: &mut Formatter<'_>) -> FmtResult {
-                        write!(f, "a constrained {} value within {MIN}..={MAX}", stringify!($Int))
+                        write!(f, "a constrained {} value within {MIN}..={MAX}", stringify!($Num))
                     }
 
-                    $($($method!($Inner, $Arg : $visit);)*)*
+                    $($($method!($Inner, $Visit : $visit);)*)*
                 }
 
                 deserializer.$deserialize(ConstrainedVisitor)
@@ -49,10 +49,10 @@ macro_rules! constrained_deserialize_impl {
 
 // Equivalent to serde's `num_self!` and `num_as_self!` but for uint only.
 macro_rules! num_as_self_uint {
-    ($UnsInt:ty, $Arg:ty : $visit:ident) => {
-        fn $visit<E: DesError>(self, v: $Arg) -> Result<Self::Value, E> {
+    ($UnsInner:ty, $UnsInt:ty : $visit:ident) => {
+        fn $visit<E: DesError>(self, v: $UnsInt) -> Result<Self::Value, E> {
             self.guard_construction()?;
-            Self::Value::__new(v as $UnsInt)
+            Self::Value::__new(v as $UnsInner)
                 .map_err(|_| E::invalid_value(Unexpected::Unsigned(v as u64), &self))
         }
     };
@@ -60,22 +60,22 @@ macro_rules! num_as_self_uint {
 
 // Equivalent to serde's `num_self!` and `num_as_self!` but for sint only.
 macro_rules! num_as_self_int {
-    ($SigInt:ty, $Arg:ty : $visit:ident) => {
-        fn $visit<E: DesError>(self, v: $Arg) -> Result<Self::Value, E> {
+    ($SigInner:ty, $SigInt:ty : $visit:ident) => {
+        fn $visit<E: DesError>(self, v: $SigInt) -> Result<Self::Value, E> {
             self.guard_construction()?;
-            Self::Value::__new(v as $SigInt)
+            Self::Value::__new(v as $SigInner)
                 .map_err(|_| E::invalid_value(Unexpected::Signed(v as i64), &self))
         }
     };
 }
 
 macro_rules! uint_to_self {
-    ($UnsInt:ty, $Arg:ty : $visit:ident) => {
-        fn $visit<E: DesError>(self, v: $Arg) -> Result<Self::Value, E> {
+    ($Inner:ty, $UnsInt:ty : $visit:ident) => {
+        fn $visit<E: DesError>(self, v: $UnsInt) -> Result<Self::Value, E> {
             self.guard_construction()?;
 
-            if v as u64 <= <$UnsInt>::MAX as u64 {
-                if let Ok(value) = Self::Value::__new(v as $UnsInt) {
+            if v as u64 <= <$Inner>::MAX as u64 {
+                if let Ok(value) = Self::Value::__new(v as $Inner) {
                     return Ok(value);
                 }
             }
@@ -85,12 +85,12 @@ macro_rules! uint_to_self {
 }
 
 macro_rules! int_to_int {
-    ($SigInt:ty, $Arg:ty : $visit:ident) => {
-        fn $visit<E: DesError>(self, v: $Arg) -> Result<Self::Value, E> {
+    ($SigInner:ty, $SigInt:ty : $visit:ident) => {
+        fn $visit<E: DesError>(self, v: $SigInt) -> Result<Self::Value, E> {
             self.guard_construction()?;
 
-            if <$SigInt>::MIN as i64 <= v as i64 && v as i64 <= <$SigInt>::MAX as i64 {
-                if let Ok(value) = Self::Value::__new(v as $SigInt) {
+            if <$SigInner>::MIN as i64 <= v as i64 && v as i64 <= <$SigInner>::MAX as i64 {
+                if let Ok(value) = Self::Value::__new(v as $SigInner) {
                     return Ok(value);
                 }
             }
@@ -100,16 +100,16 @@ macro_rules! int_to_int {
 }
 
 macro_rules! int_to_uint {
-    ($UnsInt:ty, $Arg:ty : $visit:ident) => {
-        fn $visit<E: DesError>(self, v: $Arg) -> Result<Self::Value, E> {
+    ($UnsInner:ty, $SigInt:ty : $visit:ident) => {
+        fn $visit<E: DesError>(self, v: $SigInt) -> Result<Self::Value, E> {
             self.guard_construction()?;
 
-            if 0 < v && v as u64 <= <$UnsInt>::MAX as u64 {
-                Self::Value::__new(v as $UnsInt)
-                    .map_err(|_| E::invalid_value(Unexpected::Unsigned(v as u64), &self))
-            } else {
-                Err(E::invalid_value(Unexpected::Signed(v as i64), &self))
+            if 0 < v && v as u64 <= <$UnsInner>::MAX as u64 {
+                if let Ok(value) = Self::Value::__new(v as $UnsInner) {
+                    return Ok(value);
+                }
             }
+            Err(E::invalid_value(Unexpected::Signed(v as i64), &self))
         }
     };
 }

--- a/src/deserialize/macros.rs
+++ b/src/deserialize/macros.rs
@@ -73,7 +73,7 @@ macro_rules! num_as_self_int {
     };
 }
 
-// Casts a uint visitor to inner's type, if representable. Then constructs the
+// Casts a uint visit to inner's type, if representable. Then constructs the
 // container if the range definition is valid, and the value is within range.
 macro_rules! uint_to_self {
     ($Inner:ty, $UnsInt:ty : $visit:ident) => {
@@ -90,7 +90,7 @@ macro_rules! uint_to_self {
     };
 }
 
-// Casts a int visitor to inner's (int) type, if representable. Then constructs the
+// Casts a int visit to inner's (int) type, if representable. Then constructs the
 // container if the range definition is valid, and the value is within range.
 macro_rules! int_to_int {
     ($SigInner:ty, $SigInt:ty : $visit:ident) => {
@@ -107,7 +107,7 @@ macro_rules! int_to_int {
     };
 }
 
-// Casts a int visitor to inner's (uint) type, if representable. Then constructs the
+// Casts a int visit to inner's (uint) type, if representable. Then constructs the
 // container if the range definiton is valid, and the value is within range.
 macro_rules! int_to_uint {
     ($UnsInner:ty, $SigInt:ty : $visit:ident) => {
@@ -124,7 +124,7 @@ macro_rules! int_to_uint {
     };
 }
 
-// Casts a 128bit visitor to inner's (128bit) type, if representable. Then constructs the
+// Casts a 128bit visit to inner's (128bit) type, if representable. Then constructs the
 // container if the range definiton is valid, and the value is within range.
 #[cfg(not(cnst8bitonly))]
 macro_rules! num_128 {

--- a/src/deserialize/mod.rs
+++ b/src/deserialize/mod.rs
@@ -41,6 +41,14 @@ constrained_deserialize_impl! {
     int_to_uint!(usize, i8:visit_i8 i16:visit_i16 i32:visit_i32 i64:visit_i64);
 }
 
+#[cfg(not(cnst8bitonly))]
+constrained_deserialize_impl! {
+    u128, u128, ConstrainedU128, deserialize_u128,
+    num_as_self_uint!(u128, u8:visit_u8 u16:visit_u16 u32:visit_u32 u64:visit_u64 u128:visit_u128);
+    num_as_self_int!(u128, i8:visit_i8 i16:visit_i16 i32:visit_i32 i64:visit_i64);
+    num_128!(u128, i128:visit_i128);
+}
+
 #[cfg(any(cnst8bitonly, not(cnst8bitonly)))]
 constrained_deserialize_impl! {
     i8, i8, ConstrainedI8, deserialize_i8,
@@ -78,4 +86,12 @@ constrained_deserialize_impl! {
     num_as_self_int!(isize, i8:visit_i8  i16:visit_i16);
     int_to_int!(isize, i32:visit_i32 i64:visit_i64);
     uint_to_self!(isize, u8:visit_u8 u16:visit_u16 u32:visit_u32 u64:visit_u64);
+}
+
+#[cfg(not(cnst8bitonly))]
+constrained_deserialize_impl! {
+    i128, i128, ConstrainedI128, deserialize_i128,
+    num_as_self_int!(i128, i8:visit_i8 i16:visit_i16 i32:visit_i32 i64:visit_i64 i128:visit_i128);
+    num_as_self_uint!(i128, u8:visit_u8 u16:visit_u16 u32:visit_u32 u64:visit_u64);
+    num_128!(i128, u128:visit_u128);
 }

--- a/src/deserialize/mod.rs
+++ b/src/deserialize/mod.rs
@@ -1,0 +1,81 @@
+// Import all macros.
+#[macro_use]
+mod macros;
+
+#[cfg(any(cnst8bitonly, not(cnst8bitonly)))]
+constrained_deserialize_impl! {
+    u8, u8, ConstrainedU8, deserialize_u8,
+    num_as_self_uint!(u8, u8:visit_u8);
+    uint_to_self!(u8, u16:visit_u16 u32:visit_u32 u64:visit_u64);
+    int_to_uint!(u8, i8:visit_i8 i16:visit_i16 i32:visit_i32 i64:visit_i64);
+}
+
+#[cfg(not(cnst8bitonly))]
+constrained_deserialize_impl! {
+    u16, u16, ConstrainedU16, deserialize_u16,
+    num_as_self_uint!(u16, u8:visit_u8 u16:visit_u16);
+    uint_to_self!(u16, u32:visit_u32 u64:visit_u64);
+    int_to_uint!(u16, i8:visit_i8 i16:visit_i16 i32:visit_i32 i64:visit_i64);
+}
+
+#[cfg(not(cnst8bitonly))]
+constrained_deserialize_impl! {
+    u32, u32, ConstrainedU32, deserialize_u32,
+    num_as_self_uint!(u32, u8:visit_u8 u16:visit_u16 u32:visit_u32);
+    uint_to_self!(u32, u64:visit_u64);
+    int_to_uint!(u32, i8:visit_i8 i16:visit_i16 i32:visit_i32 i64:visit_i64);
+}
+
+#[cfg(not(cnst8bitonly))]
+constrained_deserialize_impl! {
+    u64, u64, ConstrainedU64, deserialize_u64,
+    num_as_self_uint!(u64, u8:visit_u8 u16:visit_u16 u32:visit_u32 u64:visit_u64);
+    int_to_uint!(u64, i8:visit_i8 i16:visit_i16 i32:visit_i32 i64:visit_i64);
+}
+
+#[cfg(not(cnst8bitonly))]
+constrained_deserialize_impl! {
+    usize, usize, ConstrainedUsize, deserialize_u64,
+    num_as_self_uint!(usize, u8:visit_u8 u16:visit_u16);
+    uint_to_self!(usize, u32:visit_u32 u64:visit_u64);
+    int_to_uint!(usize, i8:visit_i8 i16:visit_i16 i32:visit_i32 i64:visit_i64);
+}
+
+#[cfg(any(cnst8bitonly, not(cnst8bitonly)))]
+constrained_deserialize_impl! {
+    i8, i8, ConstrainedI8, deserialize_i8,
+    num_as_self_int!(i8, i8:visit_i8);
+    int_to_int!(i8, i16:visit_i16 i32:visit_i32 i64:visit_i64);
+    uint_to_self!(i8, u8:visit_u8 u16:visit_u16 u32:visit_u32 u64:visit_u64);
+}
+
+#[cfg(not(cnst8bitonly))]
+constrained_deserialize_impl! {
+    i16, i16, ConstrainedI16, deserialize_i16,
+    num_as_self_int!(i16, i8:visit_i8  i16:visit_i16);
+    int_to_int!(i16, i32:visit_i32 i64:visit_i64);
+    uint_to_self!(i16, u8:visit_u8 u16:visit_u16 u32:visit_u32 u64:visit_u64);
+}
+
+#[cfg(not(cnst8bitonly))]
+constrained_deserialize_impl! {
+    i32, i32, ConstrainedI32, deserialize_i32,
+    num_as_self_int!(i32, i8:visit_i8  i16:visit_i16 i32:visit_i32);
+    int_to_int!(i32, i64:visit_i64);
+    uint_to_self!(i32, u8:visit_u8 u16:visit_u16 u32:visit_u32 u64:visit_u64);
+}
+
+#[cfg(not(cnst8bitonly))]
+constrained_deserialize_impl! {
+    i64, i64, ConstrainedI64, deserialize_i64,
+    num_as_self_int!(i64, i8:visit_i8  i16:visit_i16 i32:visit_i32 i64:visit_i64);
+    uint_to_self!(i64, u8:visit_u8 u16:visit_u16 u32:visit_u32 u64:visit_u64);
+}
+
+#[cfg(not(cnst8bitonly))]
+constrained_deserialize_impl! {
+    isize, isize, ConstrainedIsize, deserialize_i64,
+    num_as_self_int!(isize, i8:visit_i8  i16:visit_i16);
+    int_to_int!(isize, i32:visit_i32 i64:visit_i64);
+    uint_to_self!(isize, u8:visit_u8 u16:visit_u16 u32:visit_u32 u64:visit_u64);
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -88,6 +88,12 @@
 #[macro_use]
 mod macros;
 
+#[cfg(feature = "serde")]
+mod deserialize;
+
+#[cfg(test)]
+mod proptest;
+
 // Define mods, containers, errors, tests and impls for unsigned integers with
 // default values for doc examples.
 //
@@ -127,6 +133,3 @@ constrained_int_def_impl! {
     { i128, u128, i128, u128, ConstrainedI128, ConstrainedI128Error, MinI128Error, MaxI128Error },
     { isize, usize, isize, usize, ConstrainedIsize, ConstrainedIsizeError, MinIsizeError, MaxIsizeError },
 }
-
-#[cfg(test)]
-mod proptest;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -51,15 +51,29 @@
 //!
 //! ## Feature flags
 //!
+//! This crate does not provide any default features. The features that can be
+//! enabled are: `std` and `serde`.
+//!
+//! ### std
+//!
 //! This crate does not link against the standard library by default, so it is
-//! suitable for `no_std` environments.. It does provide a `std` feature though,
+//! suitable for `no_std` environments. It does provide a `std` feature though,
 //! that enables the standard library as a dependency. By  enabling this crate's
 //! `std` feature, these additional features are provided:
 //!   - All crate's error types will implement the `std::error::Error` trait.
 //! If users already are importing the standard library on their crate, enabling
 //! `std` feature comes at no additional cost.
 //!
+//! ### serde
+//!
+//! The `serde` feature implements [`serde`]'s `Serialize` and `Deserialize` traits
+//! for all `Constrained` types. Note that the construction constraints for the
+//! const generic parameters are checked at runtime when values are deserialized
+//! to one of the `Constrained` types. See each desired type documentation for
+//! for more information about the constraints.
+//!
 //! [`generic_const_exprs`]: https://github.com/rust-lang/rust/issues/76560
+//! [`serde`]: https://docs.rs/serde/latest/serde/
 
 // No raw pointers here, maybe in another castle.
 #![forbid(unsafe_code)]

--- a/src/macros/common.rs
+++ b/src/macros/common.rs
@@ -642,14 +642,14 @@ macro_rules! constrained_def_impl {
         }
 
         impl<const MIN: $Int, const MAX: $Int> $Err<MIN, MAX> {
-            /// Returns [`Lower`] variant.
+            /// Returns `Lower` variant.
             #[must_use]
             #[inline(always)]
             const fn lower() -> Self {
                 Self::Lower($MinErr::<MIN>::new())
             }
 
-            /// Returns [`Greater`] variant.
+            /// Returns `Greater` variant.
             #[must_use]
             #[inline(always)]
             const fn greater() -> Self {

--- a/src/macros/common.rs
+++ b/src/macros/common.rs
@@ -68,7 +68,13 @@ macro_rules! constrained_def_impl {
         /// The condition `MAX` > `MIN` **must** be satified, or else the type can't
         /// be constructed.
         ///
-        /// A default can be supplied by assigning a value to the parameter `DEF`.
+        /// A default can be supplied by assigning a value to the parameter `DEF`. The
+        /// default value must be contained by the range, meaning: `MIN` <= `DEF` <= `MAX`.
+        /// Or else the type can't be constructed.
+        ///
+        /// It's also required that either `MIN` to be greater than the primitive's `MIN`
+        /// or `MAX` to be lower than the primitive's `MAX`, or else the type can't be
+        /// constructed.
         ///
         /// # Examples
         ///

--- a/tarpaulin.toml
+++ b/tarpaulin.toml
@@ -1,2 +1,7 @@
 [main]
-features = "std"
+all-features = true
+ignore-tests = true
+# Else tarpaulin will report uncovered
+# code for the macro calls at lib.
+exclude-files = ["src/lib.rs"]
+out = ["Xml"]

--- a/tests/deserialize.rs
+++ b/tests/deserialize.rs
@@ -1,0 +1,381 @@
+use serde_test::{assert_de_tokens, Token};
+
+#[test]
+fn deserialize_cnst_i8() {
+    use constrained_int::i8::ConstrainedI8;
+    type CnstMin = ConstrainedI8<{ i8::MIN }, { i8::MAX - 1 }>;
+    type CnstMax = ConstrainedI8<{ i8::MIN + 1 }, { i8::MAX }>;
+
+    let assert_min = |v, t| assert_de_tokens(&CnstMin::new(v).unwrap(), t);
+    let assert_max = |v, t| assert_de_tokens(&CnstMax::new(v).unwrap(), t);
+
+    // From signed.
+    assert_min(-128, &[Token::I8(-128)]);
+    assert_min(-128, &[Token::I16(-128)]);
+    assert_min(-128, &[Token::I32(-128)]);
+    assert_min(-128, &[Token::I64(-128)]);
+
+    assert_max(127, &[Token::I8(127)]);
+    assert_max(127, &[Token::I16(127)]);
+    assert_max(127, &[Token::I32(127)]);
+    assert_max(127, &[Token::I64(127)]);
+
+    // From unsigned.
+    assert_min(0, &[Token::U8(0)]);
+    assert_min(0, &[Token::U16(0)]);
+    assert_min(0, &[Token::U32(0)]);
+    assert_min(0, &[Token::U64(0)]);
+
+    assert_max(127, &[Token::U8(127)]);
+    assert_max(127, &[Token::U16(127)]);
+    assert_max(127, &[Token::U32(127)]);
+    assert_max(127, &[Token::U64(127)]);
+}
+
+#[test]
+fn deserialize_cnst_i16() {
+    use constrained_int::i16::ConstrainedI16;
+    type CnstMin = ConstrainedI16<{ i16::MIN }, { i16::MAX - 1 }>;
+    type CnstMax = ConstrainedI16<{ i16::MIN + 1 }, { i16::MAX }>;
+
+    let assert_min = |v, t| assert_de_tokens(&CnstMin::new(v).unwrap(), t);
+    let assert_max = |v, t| assert_de_tokens(&CnstMax::new(v).unwrap(), t);
+
+    // From signed.
+    assert_min(-128, &[Token::I8(-128)]);
+    assert_min(-32768, &[Token::I16(-32768)]);
+    assert_min(-32768, &[Token::I32(-32768)]);
+    assert_min(-32768, &[Token::I64(-32768)]);
+
+    assert_max(127, &[Token::I8(127)]);
+    assert_max(32767, &[Token::I16(32767)]);
+    assert_max(32767, &[Token::I32(32767)]);
+    assert_max(32767, &[Token::I64(32767)]);
+
+    // From unsigned.
+    assert_min(0, &[Token::U8(0)]);
+    assert_min(0, &[Token::U16(0)]);
+    assert_min(0, &[Token::U32(0)]);
+    assert_min(0, &[Token::U64(0)]);
+
+    assert_max(255, &[Token::U8(255)]);
+    assert_max(32767, &[Token::U16(32767)]);
+    assert_max(32767, &[Token::U32(32767)]);
+    assert_max(32767, &[Token::U64(32767)]);
+}
+
+#[test]
+fn deserialize_cnst_i32() {
+    use constrained_int::i32::ConstrainedI32;
+    type CnstMin = ConstrainedI32<{ i32::MIN }, { i32::MAX - 1 }>;
+    type CnstMax = ConstrainedI32<{ i32::MIN + 1 }, { i32::MAX }>;
+
+    let assert_min = |v, t| assert_de_tokens(&CnstMin::new(v).unwrap(), t);
+    let assert_max = |v, t| assert_de_tokens(&CnstMax::new(v).unwrap(), t);
+
+    // From signed.
+    assert_min(-128, &[Token::I8(-128)]);
+    assert_min(-32768, &[Token::I16(-32768)]);
+    assert_min(-2147483648, &[Token::I32(-2147483648)]);
+    assert_min(-2147483648, &[Token::I64(-2147483648)]);
+
+    assert_max(127, &[Token::I8(127)]);
+    assert_max(32767, &[Token::I16(32767)]);
+    assert_max(2147483647, &[Token::I32(2147483647)]);
+    assert_max(2147483647, &[Token::I64(2147483647)]);
+
+    // From unsigned.
+    assert_min(0, &[Token::U8(0)]);
+    assert_min(0, &[Token::U16(0)]);
+    assert_min(0, &[Token::U32(0)]);
+    assert_min(0, &[Token::U64(0)]);
+
+    assert_max(255, &[Token::U8(255)]);
+    assert_max(65535, &[Token::U16(65535)]);
+    assert_max(2147483647, &[Token::U32(2147483647)]);
+    assert_max(2147483647, &[Token::U64(2147483647)]);
+}
+
+#[test]
+fn deserialize_cnst_i64() {
+    use constrained_int::i64::ConstrainedI64;
+    type CnstMin = ConstrainedI64<{ i64::MIN }, { i64::MAX - 1 }>;
+    type CnstMax = ConstrainedI64<{ i64::MIN + 1 }, { i64::MAX }>;
+
+    let assert_min = |v, t| assert_de_tokens(&CnstMin::new(v).unwrap(), t);
+    let assert_max = |v, t| assert_de_tokens(&CnstMax::new(v).unwrap(), t);
+
+    // From signed.
+    assert_min(-128, &[Token::I8(-128)]);
+    assert_min(-32768, &[Token::I16(-32768)]);
+    assert_min(-2147483648, &[Token::I32(-2147483648)]);
+    assert_min(-9223372036854775808, &[Token::I64(-9223372036854775808)]);
+
+    assert_max(127, &[Token::I8(127)]);
+    assert_max(32767, &[Token::I16(32767)]);
+    assert_max(2147483647, &[Token::I32(2147483647)]);
+    assert_max(9223372036854775807, &[Token::I64(9223372036854775807)]);
+
+    // From unsigned.
+    assert_min(0, &[Token::U8(0)]);
+    assert_min(0, &[Token::U16(0)]);
+    assert_min(0, &[Token::U32(0)]);
+    assert_min(0, &[Token::U64(0)]);
+
+    assert_max(255, &[Token::U8(255)]);
+    assert_max(65535, &[Token::U16(65535)]);
+    assert_max(4294967295, &[Token::U32(4294967295)]);
+    assert_max(9223372036854775807, &[Token::U64(9223372036854775807)]);
+}
+
+#[test]
+fn deserialize_cnst_isize() {
+    use constrained_int::isize::ConstrainedIsize;
+    type Cnst = ConstrainedIsize<-8, 8>;
+
+    let assert = |v, t| assert_de_tokens(&Cnst::new(v).unwrap(), t);
+
+    // From signed.
+    assert(-8, &[Token::I8(-8)]);
+    assert(-8, &[Token::I16(-8)]);
+    assert(-8, &[Token::I32(-8)]);
+    assert(-8, &[Token::I64(-8)]);
+
+    assert(8, &[Token::I8(8)]);
+    assert(8, &[Token::I16(8)]);
+    assert(8, &[Token::I32(8)]);
+    assert(8, &[Token::I64(8)]);
+
+    // From unsigned.
+    assert(0, &[Token::U8(0)]);
+    assert(0, &[Token::U16(0)]);
+    assert(0, &[Token::U32(0)]);
+    assert(0, &[Token::U64(0)]);
+
+    assert(8, &[Token::U8(8)]);
+    assert(8, &[Token::U16(8)]);
+    assert(8, &[Token::U32(8)]);
+    assert(8, &[Token::U64(8)]);
+}
+
+#[test]
+fn deserialize_cnst_i128() {
+    use constrained_int::i128::ConstrainedI128;
+    type CnstMin = ConstrainedI128<{ i128::MIN }, { i128::MAX - 1 }>;
+    type CnstMax = ConstrainedI128<{ i128::MIN + 1 }, { i128::MAX }>;
+
+    let assert_min = |v, t| assert_de_tokens(&CnstMin::new(v).unwrap(), t);
+    let assert_max = |v, t| assert_de_tokens(&CnstMax::new(v).unwrap(), t);
+
+    // From signed.
+    assert_min(-128, &[Token::I8(-128)]);
+    assert_min(-32768, &[Token::I16(-32768)]);
+    assert_min(-2147483648, &[Token::I32(-2147483648)]);
+    assert_min(-9223372036854775808, &[Token::I64(-9223372036854775808)]);
+
+    assert_max(127, &[Token::I8(127)]);
+    assert_max(32767, &[Token::I16(32767)]);
+    assert_max(2147483647, &[Token::I32(2147483647)]);
+    assert_max(9223372036854775807, &[Token::I64(9223372036854775807)]);
+
+    // From unsigned.
+    assert_min(0, &[Token::U8(0)]);
+    assert_min(0, &[Token::U16(0)]);
+    assert_min(0, &[Token::U32(0)]);
+    assert_min(0, &[Token::U64(0)]);
+
+    assert_max(255, &[Token::U8(255)]);
+    assert_max(65535, &[Token::U16(65535)]);
+    assert_max(4294967295, &[Token::U32(4294967295)]);
+    assert_max(18446744073709551615, &[Token::U64(18446744073709551615)]);
+}
+
+#[test]
+fn deserialize_cnst_u8() {
+    use constrained_int::u8::ConstrainedU8;
+    type CnstMin = ConstrainedU8<{ u8::MIN }, { u8::MAX - 1 }>;
+    type CnstMax = ConstrainedU8<{ u8::MIN + 1 }, { u8::MAX }>;
+
+    let assert_min = |v, t| assert_de_tokens(&CnstMin::new(v).unwrap(), t);
+    let assert_max = |v, t| assert_de_tokens(&CnstMax::new(v).unwrap(), t);
+
+    // From signed.
+    assert_min(0, &[Token::I8(0)]);
+    assert_min(0, &[Token::I16(0)]);
+    assert_min(0, &[Token::I32(0)]);
+    assert_min(0, &[Token::I64(0)]);
+
+    assert_max(127, &[Token::I8(127)]);
+    assert_max(255, &[Token::I16(255)]);
+    assert_max(255, &[Token::I32(255)]);
+    assert_max(255, &[Token::I64(255)]);
+
+    // From unsigned.
+    assert_min(0, &[Token::U8(0)]);
+    assert_min(0, &[Token::U16(0)]);
+    assert_min(0, &[Token::U32(0)]);
+    assert_min(0, &[Token::U64(0)]);
+
+    assert_max(255, &[Token::U8(255)]);
+    assert_max(255, &[Token::U16(255)]);
+    assert_max(255, &[Token::U32(255)]);
+    assert_max(255, &[Token::U64(255)]);
+}
+
+#[test]
+fn deserialize_cnst_u16() {
+    use constrained_int::u16::ConstrainedU16;
+    type CnstMin = ConstrainedU16<{ u16::MIN }, { u16::MAX - 1 }>;
+    type CnstMax = ConstrainedU16<{ u16::MIN + 1 }, { u16::MAX }>;
+
+    let assert_min = |v, t| assert_de_tokens(&CnstMin::new(v).unwrap(), t);
+    let assert_max = |v, t| assert_de_tokens(&CnstMax::new(v).unwrap(), t);
+
+    // From signed.
+    assert_min(0, &[Token::I8(0)]);
+    assert_min(0, &[Token::I16(0)]);
+    assert_min(0, &[Token::I32(0)]);
+    assert_min(0, &[Token::I64(0)]);
+
+    assert_max(127, &[Token::I8(127)]);
+    assert_max(32767, &[Token::I16(32767)]);
+    assert_max(65535, &[Token::I32(65535)]);
+    assert_max(65535, &[Token::I64(65535)]);
+
+    // From unsigned.
+    assert_min(0, &[Token::U8(0)]);
+    assert_min(0, &[Token::U16(0)]);
+    assert_min(0, &[Token::U32(0)]);
+    assert_min(0, &[Token::U64(0)]);
+
+    assert_max(255, &[Token::U8(255)]);
+    assert_max(65535, &[Token::U16(65535)]);
+    assert_max(65535, &[Token::U32(65535)]);
+    assert_max(65535, &[Token::U64(65535)]);
+}
+
+#[test]
+fn deserialize_cnst_u32() {
+    use constrained_int::u32::ConstrainedU32;
+    type CnstMin = ConstrainedU32<{ u32::MIN }, { u32::MAX - 1 }>;
+    type CnstMax = ConstrainedU32<{ u32::MIN + 1 }, { u32::MAX }>;
+
+    let assert_min = |v, t| assert_de_tokens(&CnstMin::new(v).unwrap(), t);
+    let assert_max = |v, t| assert_de_tokens(&CnstMax::new(v).unwrap(), t);
+
+    // From signed.
+    assert_min(0, &[Token::I8(0)]);
+    assert_min(0, &[Token::I16(0)]);
+    assert_min(0, &[Token::I32(0)]);
+    assert_min(0, &[Token::I64(0)]);
+
+    assert_max(127, &[Token::I8(127)]);
+    assert_max(32767, &[Token::I16(32767)]);
+    assert_max(2147483647, &[Token::I32(2147483647)]);
+    assert_max(4294967295, &[Token::I64(4294967295)]);
+
+    // From unsigned.
+    assert_min(0, &[Token::U8(0)]);
+    assert_min(0, &[Token::U16(0)]);
+    assert_min(0, &[Token::U32(0)]);
+    assert_min(0, &[Token::U64(0)]);
+
+    assert_max(255, &[Token::U8(255)]);
+    assert_max(65535, &[Token::U16(65535)]);
+    assert_max(4294967295, &[Token::U32(4294967295)]);
+    assert_max(4294967295, &[Token::U64(4294967295)]);
+}
+
+#[test]
+fn deserialize_cnst_u64() {
+    use constrained_int::u64::ConstrainedU64;
+    type CnstMin = ConstrainedU64<{ u64::MIN }, { u64::MAX - 1 }>;
+    type CnstMax = ConstrainedU64<{ u64::MIN + 1 }, { u64::MAX }>;
+
+    let assert_min = |v, t| assert_de_tokens(&CnstMin::new(v).unwrap(), t);
+    let assert_max = |v, t| assert_de_tokens(&CnstMax::new(v).unwrap(), t);
+
+    // From signed.
+    assert_min(0, &[Token::I8(0)]);
+    assert_min(0, &[Token::I16(0)]);
+    assert_min(0, &[Token::I32(0)]);
+    assert_min(0, &[Token::I64(0)]);
+
+    assert_max(127, &[Token::I8(127)]);
+    assert_max(32767, &[Token::I16(32767)]);
+    assert_max(2147483647, &[Token::I32(2147483647)]);
+    assert_max(9223372036854775807, &[Token::I64(9223372036854775807)]);
+
+    // From unsigned.
+    assert_min(0, &[Token::U8(0)]);
+    assert_min(0, &[Token::U16(0)]);
+    assert_min(0, &[Token::U32(0)]);
+    assert_min(0, &[Token::U64(0)]);
+
+    assert_max(255, &[Token::U8(255)]);
+    assert_max(65535, &[Token::U16(65535)]);
+    assert_max(4294967295, &[Token::U32(4294967295)]);
+    assert_max(18446744073709551615, &[Token::U64(18446744073709551615)]);
+}
+
+#[test]
+fn deserialize_cnst_usize() {
+    use constrained_int::usize::ConstrainedUsize;
+    type Cnst = ConstrainedUsize<0, 8>;
+
+    let assert = |v, t| assert_de_tokens(&Cnst::new(v).unwrap(), t);
+
+    // From signed.
+    assert(0, &[Token::I8(0)]);
+    assert(0, &[Token::I16(0)]);
+    assert(0, &[Token::I32(0)]);
+    assert(0, &[Token::I64(0)]);
+
+    assert(8, &[Token::I8(8)]);
+    assert(8, &[Token::I16(8)]);
+    assert(8, &[Token::I32(8)]);
+    assert(8, &[Token::I64(8)]);
+
+    // From unsigned.
+    assert(0, &[Token::U8(0)]);
+    assert(0, &[Token::U16(0)]);
+    assert(0, &[Token::U32(0)]);
+    assert(0, &[Token::U64(0)]);
+
+    assert(8, &[Token::U8(8)]);
+    assert(8, &[Token::U16(8)]);
+    assert(8, &[Token::U32(8)]);
+    assert(8, &[Token::U64(8)]);
+}
+
+#[test]
+fn deserialize_cnst_u128() {
+    use constrained_int::u128::ConstrainedU128;
+    type CnstMin = ConstrainedU128<{ u128::MIN }, { u128::MAX - 1 }>;
+    type CnstMax = ConstrainedU128<{ u128::MIN + 1 }, { u128::MAX }>;
+
+    let assert_min = |v, t| assert_de_tokens(&CnstMin::new(v).unwrap(), t);
+    let assert_max = |v, t| assert_de_tokens(&CnstMax::new(v).unwrap(), t);
+
+    // From signed.
+    assert_min(0, &[Token::I8(0)]);
+    assert_min(0, &[Token::I16(0)]);
+    assert_min(0, &[Token::I32(0)]);
+    assert_min(0, &[Token::I64(0)]);
+
+    assert_max(127, &[Token::I8(127)]);
+    assert_max(32767, &[Token::I16(32767)]);
+    assert_max(2147483647, &[Token::I32(2147483647)]);
+    assert_max(9223372036854775807, &[Token::I64(9223372036854775807)]);
+
+    // From unsigned.
+    assert_min(0, &[Token::U8(0)]);
+    assert_min(0, &[Token::U16(0)]);
+    assert_min(0, &[Token::U32(0)]);
+    assert_min(0, &[Token::U64(0)]);
+
+    assert_max(255, &[Token::U8(255)]);
+    assert_max(65535, &[Token::U16(65535)]);
+    assert_max(4294967295, &[Token::U32(4294967295)]);
+    assert_max(18446744073709551615, &[Token::U64(18446744073709551615)]);
+}

--- a/tests/deserialize.rs
+++ b/tests/deserialize.rs
@@ -1,7 +1,7 @@
 use serde_test::{assert_de_tokens, Token};
 
 #[test]
-fn deserialize_cnst_i8() {
+fn bounded_value_cnst_i8() {
     use constrained_int::i8::ConstrainedI8;
     type CnstMin = ConstrainedI8<{ i8::MIN }, { i8::MAX - 1 }>;
     type CnstMax = ConstrainedI8<{ i8::MIN + 1 }, { i8::MAX }>;
@@ -33,7 +33,7 @@ fn deserialize_cnst_i8() {
 }
 
 #[test]
-fn deserialize_cnst_i16() {
+fn bounded_value_cnst_i16() {
     use constrained_int::i16::ConstrainedI16;
     type CnstMin = ConstrainedI16<{ i16::MIN }, { i16::MAX - 1 }>;
     type CnstMax = ConstrainedI16<{ i16::MIN + 1 }, { i16::MAX }>;
@@ -65,7 +65,7 @@ fn deserialize_cnst_i16() {
 }
 
 #[test]
-fn deserialize_cnst_i32() {
+fn bounded_value_cnst_i32() {
     use constrained_int::i32::ConstrainedI32;
     type CnstMin = ConstrainedI32<{ i32::MIN }, { i32::MAX - 1 }>;
     type CnstMax = ConstrainedI32<{ i32::MIN + 1 }, { i32::MAX }>;
@@ -97,7 +97,7 @@ fn deserialize_cnst_i32() {
 }
 
 #[test]
-fn deserialize_cnst_i64() {
+fn bounded_value_cnst_i64() {
     use constrained_int::i64::ConstrainedI64;
     type CnstMin = ConstrainedI64<{ i64::MIN }, { i64::MAX - 1 }>;
     type CnstMax = ConstrainedI64<{ i64::MIN + 1 }, { i64::MAX }>;
@@ -129,7 +129,7 @@ fn deserialize_cnst_i64() {
 }
 
 #[test]
-fn deserialize_cnst_isize() {
+fn bounded_value_cnst_isize() {
     use constrained_int::isize::ConstrainedIsize;
     type Cnst = ConstrainedIsize<-8, 8>;
 
@@ -159,7 +159,7 @@ fn deserialize_cnst_isize() {
 }
 
 #[test]
-fn deserialize_cnst_i128() {
+fn bounded_value_cnst_i128() {
     use constrained_int::i128::ConstrainedI128;
     type CnstMin = ConstrainedI128<{ i128::MIN }, { i128::MAX - 1 }>;
     type CnstMax = ConstrainedI128<{ i128::MIN + 1 }, { i128::MAX }>;
@@ -191,7 +191,7 @@ fn deserialize_cnst_i128() {
 }
 
 #[test]
-fn deserialize_cnst_u8() {
+fn bounded_value_cnst_u8() {
     use constrained_int::u8::ConstrainedU8;
     type CnstMin = ConstrainedU8<{ u8::MIN }, { u8::MAX - 1 }>;
     type CnstMax = ConstrainedU8<{ u8::MIN + 1 }, { u8::MAX }>;
@@ -223,7 +223,7 @@ fn deserialize_cnst_u8() {
 }
 
 #[test]
-fn deserialize_cnst_u16() {
+fn bounded_value_cnst_u16() {
     use constrained_int::u16::ConstrainedU16;
     type CnstMin = ConstrainedU16<{ u16::MIN }, { u16::MAX - 1 }>;
     type CnstMax = ConstrainedU16<{ u16::MIN + 1 }, { u16::MAX }>;
@@ -255,7 +255,7 @@ fn deserialize_cnst_u16() {
 }
 
 #[test]
-fn deserialize_cnst_u32() {
+fn bounded_value_cnst_u32() {
     use constrained_int::u32::ConstrainedU32;
     type CnstMin = ConstrainedU32<{ u32::MIN }, { u32::MAX - 1 }>;
     type CnstMax = ConstrainedU32<{ u32::MIN + 1 }, { u32::MAX }>;
@@ -287,7 +287,7 @@ fn deserialize_cnst_u32() {
 }
 
 #[test]
-fn deserialize_cnst_u64() {
+fn bounded_value_cnst_u64() {
     use constrained_int::u64::ConstrainedU64;
     type CnstMin = ConstrainedU64<{ u64::MIN }, { u64::MAX - 1 }>;
     type CnstMax = ConstrainedU64<{ u64::MIN + 1 }, { u64::MAX }>;
@@ -319,7 +319,7 @@ fn deserialize_cnst_u64() {
 }
 
 #[test]
-fn deserialize_cnst_usize() {
+fn bounded_value_cnst_usize() {
     use constrained_int::usize::ConstrainedUsize;
     type Cnst = ConstrainedUsize<0, 8>;
 
@@ -349,7 +349,7 @@ fn deserialize_cnst_usize() {
 }
 
 #[test]
-fn deserialize_cnst_u128() {
+fn bounded_value_cnst_u128() {
     use constrained_int::u128::ConstrainedU128;
     type CnstMin = ConstrainedU128<{ u128::MIN }, { u128::MAX - 1 }>;
     type CnstMax = ConstrainedU128<{ u128::MIN + 1 }, { u128::MAX }>;

--- a/tests/deserialize.rs
+++ b/tests/deserialize.rs
@@ -1,6 +1,7 @@
 use serde_test::{assert_de_tokens, Token};
 
 #[test]
+#[cfg(any(cnst8bitonly, not(cnst8bitonly)))]
 fn bounded_value_cnst_i8() {
     use constrained_int::i8::ConstrainedI8;
     type CnstMin = ConstrainedI8<{ i8::MIN }, { i8::MAX - 1 }>;
@@ -33,6 +34,7 @@ fn bounded_value_cnst_i8() {
 }
 
 #[test]
+#[cfg(not(cnst8bitonly))]
 fn bounded_value_cnst_i16() {
     use constrained_int::i16::ConstrainedI16;
     type CnstMin = ConstrainedI16<{ i16::MIN }, { i16::MAX - 1 }>;
@@ -65,6 +67,7 @@ fn bounded_value_cnst_i16() {
 }
 
 #[test]
+#[cfg(not(cnst8bitonly))]
 fn bounded_value_cnst_i32() {
     use constrained_int::i32::ConstrainedI32;
     type CnstMin = ConstrainedI32<{ i32::MIN }, { i32::MAX - 1 }>;
@@ -97,6 +100,7 @@ fn bounded_value_cnst_i32() {
 }
 
 #[test]
+#[cfg(not(cnst8bitonly))]
 fn bounded_value_cnst_i64() {
     use constrained_int::i64::ConstrainedI64;
     type CnstMin = ConstrainedI64<{ i64::MIN }, { i64::MAX - 1 }>;
@@ -129,6 +133,7 @@ fn bounded_value_cnst_i64() {
 }
 
 #[test]
+#[cfg(not(cnst8bitonly))]
 fn bounded_value_cnst_isize() {
     use constrained_int::isize::ConstrainedIsize;
     type Cnst = ConstrainedIsize<-8, 8>;
@@ -159,6 +164,7 @@ fn bounded_value_cnst_isize() {
 }
 
 #[test]
+#[cfg(not(cnst8bitonly))]
 fn bounded_value_cnst_i128() {
     use constrained_int::i128::ConstrainedI128;
     type CnstMin = ConstrainedI128<{ i128::MIN }, { i128::MAX - 1 }>;
@@ -191,6 +197,7 @@ fn bounded_value_cnst_i128() {
 }
 
 #[test]
+#[cfg(any(cnst8bitonly, not(cnst8bitonly)))]
 fn bounded_value_cnst_u8() {
     use constrained_int::u8::ConstrainedU8;
     type CnstMin = ConstrainedU8<{ u8::MIN }, { u8::MAX - 1 }>;
@@ -223,6 +230,7 @@ fn bounded_value_cnst_u8() {
 }
 
 #[test]
+#[cfg(not(cnst8bitonly))]
 fn bounded_value_cnst_u16() {
     use constrained_int::u16::ConstrainedU16;
     type CnstMin = ConstrainedU16<{ u16::MIN }, { u16::MAX - 1 }>;
@@ -255,6 +263,7 @@ fn bounded_value_cnst_u16() {
 }
 
 #[test]
+#[cfg(not(cnst8bitonly))]
 fn bounded_value_cnst_u32() {
     use constrained_int::u32::ConstrainedU32;
     type CnstMin = ConstrainedU32<{ u32::MIN }, { u32::MAX - 1 }>;
@@ -287,6 +296,7 @@ fn bounded_value_cnst_u32() {
 }
 
 #[test]
+#[cfg(not(cnst8bitonly))]
 fn bounded_value_cnst_u64() {
     use constrained_int::u64::ConstrainedU64;
     type CnstMin = ConstrainedU64<{ u64::MIN }, { u64::MAX - 1 }>;
@@ -319,6 +329,7 @@ fn bounded_value_cnst_u64() {
 }
 
 #[test]
+#[cfg(not(cnst8bitonly))]
 fn bounded_value_cnst_usize() {
     use constrained_int::usize::ConstrainedUsize;
     type Cnst = ConstrainedUsize<0, 8>;
@@ -349,6 +360,7 @@ fn bounded_value_cnst_usize() {
 }
 
 #[test]
+#[cfg(not(cnst8bitonly))]
 fn bounded_value_cnst_u128() {
     use constrained_int::u128::ConstrainedU128;
     type CnstMin = ConstrainedU128<{ u128::MIN }, { u128::MAX - 1 }>;

--- a/tests/deserialize_error.rs
+++ b/tests/deserialize_error.rs
@@ -270,7 +270,8 @@ macro_rules! range_err {
             // serde's invalid_type.
             "invalid type: ",
             // user defined.
-            stringify!($Cnst), "<MIN, MAX, DEF>",
+            stringify!($Cnst),
+            "<MIN, MAX, DEF>",
             // serde's expecting.
             ", expected ",
             // user defined.

--- a/tests/deserialize_error.rs
+++ b/tests/deserialize_error.rs
@@ -1,0 +1,265 @@
+use serde_test::{assert_de_tokens_error, Token};
+use std::fmt::{Display, Write};
+use std::ops::RangeInclusive;
+
+fn err<V, Idx>(value: V, prim: &str, range: RangeInclusive<Idx>) -> String
+where
+    V: Display,
+    Idx: Display,
+{
+    let (min, max) = (range.start(), range.end());
+    let mut err = String::from("invalid value: integer ");
+    write!(&mut err, "`{value}`, expected a constrained {prim} value within {min}..={max}",)
+        .unwrap();
+    err
+}
+
+#[test]
+fn deserialize_error_cnst_i8() {
+    use constrained_int::i8::ConstrainedI8;
+    type CnstMin = ConstrainedI8<-128, 126>;
+    type CnstMax = ConstrainedI8<-127, 127>;
+
+    let assert_min_err = assert_de_tokens_error::<CnstMin>;
+    let assert_max_err = assert_de_tokens_error::<CnstMax>;
+
+    // From signed.
+    assert_min_err(&[Token::I8(127)], &err(127, "i8", CnstMin::range()));
+    assert_min_err(&[Token::I16(-129)], &err(-129, "i8", CnstMin::range()));
+    assert_min_err(&[Token::I16(127)], &err(127, "i8", CnstMin::range()));
+    assert_min_err(&[Token::I32(-129)], &err(-129, "i8", CnstMin::range()));
+    assert_min_err(&[Token::I32(127)], &err(127, "i8", CnstMin::range()));
+    assert_min_err(&[Token::I64(-129)], &err(-129, "i8", CnstMin::range()));
+    assert_min_err(&[Token::I64(127)], &err(127, "i8", CnstMin::range()));
+
+    assert_max_err(&[Token::I8(-128)], &err(-128, "i8", CnstMax::range()));
+    assert_max_err(&[Token::I16(-128)], &err(-128, "i8", CnstMax::range()));
+    assert_max_err(&[Token::I16(128)], &err(128, "i8", CnstMax::range()));
+    assert_max_err(&[Token::I32(-128)], &err(-128, "i8", CnstMax::range()));
+    assert_max_err(&[Token::I32(128)], &err(128, "i8", CnstMax::range()));
+    assert_max_err(&[Token::I64(-128)], &err(-128, "i8", CnstMax::range()));
+    assert_max_err(&[Token::I64(128)], &err(128, "i8", CnstMax::range()));
+
+    // From unsigned.
+    assert_min_err(&[Token::U8(127)], &err(127, "i8", CnstMin::range()));
+    assert_min_err(&[Token::U16(127)], &err(127, "i8", CnstMin::range()));
+    assert_min_err(&[Token::U32(127)], &err(127, "i8", CnstMin::range()));
+    assert_min_err(&[Token::U64(127)], &err(127, "i8", CnstMin::range()));
+
+    assert_max_err(&[Token::U8(128)], &err(128, "i8", CnstMax::range()));
+    assert_max_err(&[Token::U16(128)], &err(128, "i8", CnstMax::range()));
+    assert_max_err(&[Token::U32(128)], &err(128, "i8", CnstMax::range()));
+    assert_max_err(&[Token::U64(128)], &err(128, "i8", CnstMax::range()));
+}
+
+#[test]
+fn deserialize_error_cnst_i16() {
+    use constrained_int::i16::ConstrainedI16;
+    type CnstMin = ConstrainedI16<-32768, 32766>;
+    type CnstMax = ConstrainedI16<-32767, 32767>;
+
+    let assert_min_err = assert_de_tokens_error::<CnstMin>;
+    let assert_max_err = assert_de_tokens_error::<CnstMax>;
+
+    // From signed.
+    assert_min_err(&[Token::I16(32767)], &err(32767, "i16", CnstMin::range()));
+    assert_min_err(&[Token::I32(-32769)], &err(-32769, "i16", CnstMin::range()));
+    assert_min_err(&[Token::I32(32767)], &err(32767, "i16", CnstMin::range()));
+    assert_min_err(&[Token::I64(-32769)], &err(-32769, "i16", CnstMin::range()));
+    assert_min_err(&[Token::I64(32767)], &err(32767, "i16", CnstMin::range()));
+
+    assert_max_err(&[Token::I16(-32768)], &err(-32768, "i16", CnstMax::range()));
+    assert_max_err(&[Token::I32(-32768)], &err(-32768, "i16", CnstMax::range()));
+    assert_max_err(&[Token::I32(32768)], &err(32768, "i16", CnstMax::range()));
+    assert_max_err(&[Token::I64(-32768)], &err(-32768, "i16", CnstMax::range()));
+    assert_max_err(&[Token::I64(32768)], &err(32768, "i16", CnstMax::range()));
+
+    // From unsigned.
+    assert_min_err(&[Token::U16(32767)], &err(32767, "i16", CnstMin::range()));
+    assert_min_err(&[Token::U32(32767)], &err(32767, "i16", CnstMin::range()));
+    assert_min_err(&[Token::U64(32767)], &err(32767, "i16", CnstMin::range()));
+
+    assert_max_err(&[Token::U16(32768)], &err(32768, "i16", CnstMax::range()));
+    assert_max_err(&[Token::U32(32768)], &err(32768, "i16", CnstMax::range()));
+    assert_max_err(&[Token::U64(32768)], &err(32768, "i16", CnstMax::range()));
+}
+
+#[test]
+fn deserialize_error_cnst_i32() {
+    use constrained_int::i32::ConstrainedI32;
+    type CnstMin = ConstrainedI32<-2147483648, 2147483646>;
+    type CnstMax = ConstrainedI32<-2147483647, 2147483647>;
+
+    let assert_min_err = assert_de_tokens_error::<CnstMin>;
+    let assert_max_err = assert_de_tokens_error::<CnstMax>;
+
+    // From signed.
+    assert_min_err(&[Token::I32(2147483647)], &err(2147483647, "i32", CnstMin::range()));
+    assert_min_err(&[Token::I64(-2147483649)], &err(-2147483649_i64, "i32", CnstMin::range()));
+    assert_min_err(&[Token::I64(2147483647)], &err(2147483647, "i32", CnstMin::range()));
+
+    assert_max_err(&[Token::I32(-2147483648)], &err(-2147483648, "i32", CnstMax::range()));
+    assert_max_err(&[Token::I64(-2147483648)], &err(-2147483648, "i32", CnstMax::range()));
+    assert_max_err(&[Token::I64(2147483648)], &err(2147483648_i64, "i32", CnstMax::range()));
+
+    // From unsigned.
+    assert_min_err(&[Token::U32(2147483647)], &err(2147483647, "i32", CnstMin::range()));
+    assert_min_err(&[Token::U64(2147483647)], &err(2147483647, "i32", CnstMin::range()));
+
+    assert_max_err(&[Token::U32(2147483648)], &err(2147483648_u32, "i32", CnstMax::range()));
+    assert_max_err(&[Token::U64(2147483648)], &err(2147483648_u64, "i32", CnstMax::range()));
+}
+
+#[test]
+fn deserialize_error_cnst_i64() {
+    use constrained_int::i64::ConstrainedI64;
+    type CnstMin = ConstrainedI64<-9223372036854775808, 9223372036854775806>;
+    type CnstMax = ConstrainedI64<-9223372036854775807, 9223372036854775807>;
+
+    let assert_min_err = assert_de_tokens_error::<CnstMin>;
+    let assert_max_err = assert_de_tokens_error::<CnstMax>;
+
+    // From signed.
+    assert_min_err(
+        &[Token::I64(9223372036854775807)],
+        &err(9223372036854775807_i64, "i64", CnstMin::range()),
+    );
+
+    assert_max_err(
+        &[Token::I64(-9223372036854775808)],
+        &err(-9223372036854775808_i64, "i64", CnstMax::range()),
+    );
+
+    // From unsigned.
+    assert_min_err(
+        &[Token::U64(9223372036854775807)],
+        &err(9223372036854775807_u64, "i64", CnstMin::range()),
+    );
+
+    assert_max_err(
+        &[Token::U64(9223372036854775808)],
+        &err(9223372036854775808_u64, "i64", CnstMax::range()),
+    );
+}
+
+#[test]
+fn deserialize_error_cnst_u8() {
+    use constrained_int::u8::ConstrainedU8;
+    type CnstMin = ConstrainedU8<0, 254>;
+    type CnstMax = ConstrainedU8<1, 255>;
+
+    let assert_min_err = assert_de_tokens_error::<CnstMin>;
+    let assert_max_err = assert_de_tokens_error::<CnstMax>;
+
+    // From signed.
+    assert_min_err(&[Token::I8(-1)], &err(-1, "u8", CnstMin::range()));
+    assert_min_err(&[Token::I16(-1)], &err(-1, "u8", CnstMin::range()));
+    assert_min_err(&[Token::I16(255)], &err(255, "u8", CnstMin::range()));
+    assert_min_err(&[Token::I32(-1)], &err(-1, "u8", CnstMin::range()));
+    assert_min_err(&[Token::I32(255)], &err(255, "u8", CnstMin::range()));
+    assert_min_err(&[Token::I64(-1)], &err(-1, "u8", CnstMin::range()));
+    assert_min_err(&[Token::I64(255)], &err(255, "u8", CnstMin::range()));
+
+    assert_max_err(&[Token::I8(0)], &err(0, "u8", CnstMax::range()));
+    assert_max_err(&[Token::I16(0)], &err(0, "u8", CnstMax::range()));
+    assert_max_err(&[Token::I16(256)], &err(256, "u8", CnstMax::range()));
+    assert_max_err(&[Token::I32(0)], &err(0, "u8", CnstMax::range()));
+    assert_max_err(&[Token::I32(256)], &err(256, "u8", CnstMax::range()));
+    assert_max_err(&[Token::I32(0)], &err(0, "u8", CnstMax::range()));
+    assert_max_err(&[Token::I64(256)], &err(256, "u8", CnstMax::range()));
+
+    // From unsigned.
+    assert_min_err(&[Token::U8(255)], &err(255, "u8", CnstMin::range()));
+    assert_min_err(&[Token::U16(255)], &err(255, "u8", CnstMin::range()));
+    assert_min_err(&[Token::U32(255)], &err(255, "u8", CnstMin::range()));
+    assert_min_err(&[Token::U64(255)], &err(255, "u8", CnstMin::range()));
+
+    assert_max_err(&[Token::U16(256)], &err(256, "u8", CnstMax::range()));
+    assert_max_err(&[Token::U32(256)], &err(256, "u8", CnstMax::range()));
+    assert_max_err(&[Token::U64(256)], &err(256, "u8", CnstMax::range()));
+}
+
+#[test]
+fn deserialize_error_cnst_u16() {
+    use constrained_int::u16::ConstrainedU16;
+    type CnstMin = ConstrainedU16<0, 65534>;
+    type CnstMax = ConstrainedU16<1, 65535>;
+
+    let assert_min_err = assert_de_tokens_error::<CnstMin>;
+    let assert_max_err = assert_de_tokens_error::<CnstMax>;
+
+    // From signed.
+    assert_min_err(&[Token::I8(-1)], &err(-1, "u16", CnstMin::range()));
+    assert_min_err(&[Token::I16(-1)], &err(-1, "u16", CnstMin::range()));
+    assert_min_err(&[Token::I32(-1)], &err(-1, "u16", CnstMin::range()));
+    assert_min_err(&[Token::I32(65535)], &err(65535, "u16", CnstMin::range()));
+    assert_min_err(&[Token::I64(-1)], &err(-1, "u16", CnstMin::range()));
+    assert_min_err(&[Token::I64(65535)], &err(65535, "u16", CnstMin::range()));
+
+    assert_max_err(&[Token::I8(0)], &err(0, "u16", CnstMax::range()));
+    assert_max_err(&[Token::I16(0)], &err(0, "u16", CnstMax::range()));
+    assert_max_err(&[Token::I32(0)], &err(0, "u16", CnstMax::range()));
+    assert_max_err(&[Token::I32(65536)], &err(65536, "u16", CnstMax::range()));
+    assert_max_err(&[Token::I64(0)], &err(0, "u16", CnstMax::range()));
+    assert_max_err(&[Token::I64(65536)], &err(65536, "u16", CnstMax::range()));
+
+    // From unsigned.
+    assert_min_err(&[Token::U16(65535)], &err(65535, "u16", CnstMin::range()));
+    assert_min_err(&[Token::U32(65535)], &err(65535, "u16", CnstMin::range()));
+    assert_min_err(&[Token::U64(65535)], &err(65535, "u16", CnstMin::range()));
+
+    assert_max_err(&[Token::U32(65536)], &err(65536, "u16", CnstMax::range()));
+    assert_max_err(&[Token::U64(65536)], &err(65536, "u16", CnstMax::range()));
+}
+
+#[test]
+fn deserialize_error_cnst_u32() {
+    use constrained_int::u32::ConstrainedU32;
+    type CnstMin = ConstrainedU32<0, 4294967294>;
+    type CnstMax = ConstrainedU32<1, 4294967295>;
+
+    let assert_min_err = assert_de_tokens_error::<CnstMin>;
+    let assert_max_err = assert_de_tokens_error::<CnstMax>;
+
+    // From signed.
+    assert_min_err(&[Token::I8(-1)], &err(-1, "u32", CnstMin::range()));
+    assert_min_err(&[Token::I16(-1)], &err(-1, "u32", CnstMin::range()));
+    assert_min_err(&[Token::I32(-1)], &err(-1, "u32", CnstMin::range()));
+    assert_min_err(&[Token::I64(-1)], &err(-1, "u32", CnstMin::range()));
+    assert_min_err(&[Token::I64(4294967295)], &err(4294967295_i64, "u32", CnstMin::range()));
+
+    assert_max_err(&[Token::I8(0)], &err(0, "u32", CnstMax::range()));
+    assert_max_err(&[Token::I16(0)], &err(0, "u32", CnstMax::range()));
+    assert_max_err(&[Token::I32(0)], &err(0, "u32", CnstMax::range()));
+    assert_max_err(&[Token::I64(0)], &err(0, "u32", CnstMax::range()));
+    assert_max_err(&[Token::I64(4294967296)], &err(4294967296_i64, "u32", CnstMax::range()));
+
+    // From unsigned.
+    assert_min_err(&[Token::U32(4294967295)], &err(4294967295_u32, "u32", CnstMin::range()));
+    assert_min_err(&[Token::U64(4294967295)], &err(4294967295_u64, "u32", CnstMin::range()));
+
+    assert_max_err(&[Token::U64(4294967296)], &err(4294967296_u64, "u32", CnstMax::range()));
+}
+
+#[test]
+fn deserialize_error_cnst_u64() {
+    use constrained_int::u64::ConstrainedU64;
+    type CnstMin = ConstrainedU64<0, 18446744073709551614>;
+    type CnstMax = ConstrainedU64<1, 18446744073709551615>;
+
+    let assert_min_err = assert_de_tokens_error::<CnstMin>;
+    let assert_max_err = assert_de_tokens_error::<CnstMax>;
+
+    // From signed.
+    assert_min_err(&[Token::I8(-1)], &err(-1, "u64", CnstMin::range()));
+    assert_min_err(&[Token::I16(-1)], &err(-1, "u64", CnstMin::range()));
+    assert_min_err(&[Token::I32(-1)], &err(-1, "u64", CnstMin::range()));
+    assert_min_err(&[Token::I64(-1)], &err(-1, "u64", CnstMin::range()));
+    assert_min_err(&[Token::I64(-1)], &err(-1, "u64", CnstMin::range()));
+
+    assert_max_err(&[Token::I8(0)], &err(0, "u64", CnstMax::range()));
+    assert_max_err(&[Token::I16(0)], &err(0, "u64", CnstMax::range()));
+    assert_max_err(&[Token::I32(0)], &err(0, "u64", CnstMax::range()));
+    assert_max_err(&[Token::I64(0)], &err(0, "u64", CnstMax::range()));
+    assert_max_err(&[Token::I64(0)], &err(0, "u64", CnstMax::range()));
+}

--- a/tests/deserialize_error.rs
+++ b/tests/deserialize_error.rs
@@ -354,6 +354,7 @@ impl_invalid_range_test_for! {
     { u128, u128, ConstrainedU128, invalid_range_cnst_u128 },
     { usize, usize, ConstrainedUsize, invalid_range_cnst_usize },
 }
+
 #[cfg(any(cnst8bitonly, not(cnst8bitonly)))]
 impl_invalid_range_test_for! {
     { i8, i8, ConstrainedI8, invalid_range_cnst_i8 },

--- a/tests/deserialize_error.rs
+++ b/tests/deserialize_error.rs
@@ -2,264 +2,349 @@ use serde_test::{assert_de_tokens_error, Token};
 use std::fmt::{Display, Write};
 use std::ops::RangeInclusive;
 
-fn err<V, Idx>(value: V, prim: &str, range: RangeInclusive<Idx>) -> String
+fn val_err<V, Idx>(value: V, prim: &str, range: RangeInclusive<Idx>) -> String
 where
     V: Display,
     Idx: Display,
 {
     let (min, max) = (range.start(), range.end());
-    let mut err = String::from("invalid value: integer ");
-    write!(&mut err, "`{value}`, expected a constrained {prim} value within {min}..={max}",)
+    let mut val_err = String::from("invalid value: integer ");
+    write!(&mut val_err, "`{value}`, expected a constrained {prim} value within {min}..={max}",)
         .unwrap();
-    err
+    val_err
 }
 
 #[test]
-fn deserialize_error_cnst_i8() {
+fn unbounded_value_cnst_i8() {
     use constrained_int::i8::ConstrainedI8;
     type CnstMin = ConstrainedI8<-128, 126>;
     type CnstMax = ConstrainedI8<-127, 127>;
 
-    let assert_min_err = assert_de_tokens_error::<CnstMin>;
-    let assert_max_err = assert_de_tokens_error::<CnstMax>;
+    let min_err = assert_de_tokens_error::<CnstMin>;
+    let max_err = assert_de_tokens_error::<CnstMax>;
 
     // From signed.
-    assert_min_err(&[Token::I8(127)], &err(127, "i8", CnstMin::range()));
-    assert_min_err(&[Token::I16(-129)], &err(-129, "i8", CnstMin::range()));
-    assert_min_err(&[Token::I16(127)], &err(127, "i8", CnstMin::range()));
-    assert_min_err(&[Token::I32(-129)], &err(-129, "i8", CnstMin::range()));
-    assert_min_err(&[Token::I32(127)], &err(127, "i8", CnstMin::range()));
-    assert_min_err(&[Token::I64(-129)], &err(-129, "i8", CnstMin::range()));
-    assert_min_err(&[Token::I64(127)], &err(127, "i8", CnstMin::range()));
+    min_err(&[Token::I8(127)], &val_err(127, "i8", CnstMin::range()));
+    min_err(&[Token::I16(-129)], &val_err(-129, "i8", CnstMin::range()));
+    min_err(&[Token::I16(127)], &val_err(127, "i8", CnstMin::range()));
+    min_err(&[Token::I32(-129)], &val_err(-129, "i8", CnstMin::range()));
+    min_err(&[Token::I32(127)], &val_err(127, "i8", CnstMin::range()));
+    min_err(&[Token::I64(-129)], &val_err(-129, "i8", CnstMin::range()));
+    min_err(&[Token::I64(127)], &val_err(127, "i8", CnstMin::range()));
 
-    assert_max_err(&[Token::I8(-128)], &err(-128, "i8", CnstMax::range()));
-    assert_max_err(&[Token::I16(-128)], &err(-128, "i8", CnstMax::range()));
-    assert_max_err(&[Token::I16(128)], &err(128, "i8", CnstMax::range()));
-    assert_max_err(&[Token::I32(-128)], &err(-128, "i8", CnstMax::range()));
-    assert_max_err(&[Token::I32(128)], &err(128, "i8", CnstMax::range()));
-    assert_max_err(&[Token::I64(-128)], &err(-128, "i8", CnstMax::range()));
-    assert_max_err(&[Token::I64(128)], &err(128, "i8", CnstMax::range()));
+    max_err(&[Token::I8(-128)], &val_err(-128, "i8", CnstMax::range()));
+    max_err(&[Token::I16(-128)], &val_err(-128, "i8", CnstMax::range()));
+    max_err(&[Token::I16(128)], &val_err(128, "i8", CnstMax::range()));
+    max_err(&[Token::I32(-128)], &val_err(-128, "i8", CnstMax::range()));
+    max_err(&[Token::I32(128)], &val_err(128, "i8", CnstMax::range()));
+    max_err(&[Token::I64(-128)], &val_err(-128, "i8", CnstMax::range()));
+    max_err(&[Token::I64(128)], &val_err(128, "i8", CnstMax::range()));
 
     // From unsigned.
-    assert_min_err(&[Token::U8(127)], &err(127, "i8", CnstMin::range()));
-    assert_min_err(&[Token::U16(127)], &err(127, "i8", CnstMin::range()));
-    assert_min_err(&[Token::U32(127)], &err(127, "i8", CnstMin::range()));
-    assert_min_err(&[Token::U64(127)], &err(127, "i8", CnstMin::range()));
+    min_err(&[Token::U8(127)], &val_err(127, "i8", CnstMin::range()));
+    min_err(&[Token::U16(127)], &val_err(127, "i8", CnstMin::range()));
+    min_err(&[Token::U32(127)], &val_err(127, "i8", CnstMin::range()));
+    min_err(&[Token::U64(127)], &val_err(127, "i8", CnstMin::range()));
 
-    assert_max_err(&[Token::U8(128)], &err(128, "i8", CnstMax::range()));
-    assert_max_err(&[Token::U16(128)], &err(128, "i8", CnstMax::range()));
-    assert_max_err(&[Token::U32(128)], &err(128, "i8", CnstMax::range()));
-    assert_max_err(&[Token::U64(128)], &err(128, "i8", CnstMax::range()));
+    max_err(&[Token::U8(128)], &val_err(128, "i8", CnstMax::range()));
+    max_err(&[Token::U16(128)], &val_err(128, "i8", CnstMax::range()));
+    max_err(&[Token::U32(128)], &val_err(128, "i8", CnstMax::range()));
+    max_err(&[Token::U64(128)], &val_err(128, "i8", CnstMax::range()));
 }
 
 #[test]
-fn deserialize_error_cnst_i16() {
+fn unbounded_value_cnst_i16() {
     use constrained_int::i16::ConstrainedI16;
     type CnstMin = ConstrainedI16<-32768, 32766>;
     type CnstMax = ConstrainedI16<-32767, 32767>;
 
-    let assert_min_err = assert_de_tokens_error::<CnstMin>;
-    let assert_max_err = assert_de_tokens_error::<CnstMax>;
+    let min_err = assert_de_tokens_error::<CnstMin>;
+    let max_err = assert_de_tokens_error::<CnstMax>;
 
     // From signed.
-    assert_min_err(&[Token::I16(32767)], &err(32767, "i16", CnstMin::range()));
-    assert_min_err(&[Token::I32(-32769)], &err(-32769, "i16", CnstMin::range()));
-    assert_min_err(&[Token::I32(32767)], &err(32767, "i16", CnstMin::range()));
-    assert_min_err(&[Token::I64(-32769)], &err(-32769, "i16", CnstMin::range()));
-    assert_min_err(&[Token::I64(32767)], &err(32767, "i16", CnstMin::range()));
+    min_err(&[Token::I16(32767)], &val_err(32767, "i16", CnstMin::range()));
+    min_err(&[Token::I32(-32769)], &val_err(-32769, "i16", CnstMin::range()));
+    min_err(&[Token::I32(32767)], &val_err(32767, "i16", CnstMin::range()));
+    min_err(&[Token::I64(-32769)], &val_err(-32769, "i16", CnstMin::range()));
+    min_err(&[Token::I64(32767)], &val_err(32767, "i16", CnstMin::range()));
 
-    assert_max_err(&[Token::I16(-32768)], &err(-32768, "i16", CnstMax::range()));
-    assert_max_err(&[Token::I32(-32768)], &err(-32768, "i16", CnstMax::range()));
-    assert_max_err(&[Token::I32(32768)], &err(32768, "i16", CnstMax::range()));
-    assert_max_err(&[Token::I64(-32768)], &err(-32768, "i16", CnstMax::range()));
-    assert_max_err(&[Token::I64(32768)], &err(32768, "i16", CnstMax::range()));
+    max_err(&[Token::I16(-32768)], &val_err(-32768, "i16", CnstMax::range()));
+    max_err(&[Token::I32(-32768)], &val_err(-32768, "i16", CnstMax::range()));
+    max_err(&[Token::I32(32768)], &val_err(32768, "i16", CnstMax::range()));
+    max_err(&[Token::I64(-32768)], &val_err(-32768, "i16", CnstMax::range()));
+    max_err(&[Token::I64(32768)], &val_err(32768, "i16", CnstMax::range()));
 
     // From unsigned.
-    assert_min_err(&[Token::U16(32767)], &err(32767, "i16", CnstMin::range()));
-    assert_min_err(&[Token::U32(32767)], &err(32767, "i16", CnstMin::range()));
-    assert_min_err(&[Token::U64(32767)], &err(32767, "i16", CnstMin::range()));
+    min_err(&[Token::U16(32767)], &val_err(32767, "i16", CnstMin::range()));
+    min_err(&[Token::U32(32767)], &val_err(32767, "i16", CnstMin::range()));
+    min_err(&[Token::U64(32767)], &val_err(32767, "i16", CnstMin::range()));
 
-    assert_max_err(&[Token::U16(32768)], &err(32768, "i16", CnstMax::range()));
-    assert_max_err(&[Token::U32(32768)], &err(32768, "i16", CnstMax::range()));
-    assert_max_err(&[Token::U64(32768)], &err(32768, "i16", CnstMax::range()));
+    max_err(&[Token::U16(32768)], &val_err(32768, "i16", CnstMax::range()));
+    max_err(&[Token::U32(32768)], &val_err(32768, "i16", CnstMax::range()));
+    max_err(&[Token::U64(32768)], &val_err(32768, "i16", CnstMax::range()));
 }
 
 #[test]
-fn deserialize_error_cnst_i32() {
+fn unbounded_value_cnst_i32() {
     use constrained_int::i32::ConstrainedI32;
     type CnstMin = ConstrainedI32<-2147483648, 2147483646>;
     type CnstMax = ConstrainedI32<-2147483647, 2147483647>;
 
-    let assert_min_err = assert_de_tokens_error::<CnstMin>;
-    let assert_max_err = assert_de_tokens_error::<CnstMax>;
+    let min_err = assert_de_tokens_error::<CnstMin>;
+    let max_err = assert_de_tokens_error::<CnstMax>;
 
     // From signed.
-    assert_min_err(&[Token::I32(2147483647)], &err(2147483647, "i32", CnstMin::range()));
-    assert_min_err(&[Token::I64(-2147483649)], &err(-2147483649_i64, "i32", CnstMin::range()));
-    assert_min_err(&[Token::I64(2147483647)], &err(2147483647, "i32", CnstMin::range()));
+    min_err(&[Token::I32(2147483647)], &val_err(2147483647, "i32", CnstMin::range()));
+    min_err(&[Token::I64(-2147483649)], &val_err(-2147483649_i64, "i32", CnstMin::range()));
+    min_err(&[Token::I64(2147483647)], &val_err(2147483647, "i32", CnstMin::range()));
 
-    assert_max_err(&[Token::I32(-2147483648)], &err(-2147483648, "i32", CnstMax::range()));
-    assert_max_err(&[Token::I64(-2147483648)], &err(-2147483648, "i32", CnstMax::range()));
-    assert_max_err(&[Token::I64(2147483648)], &err(2147483648_i64, "i32", CnstMax::range()));
+    max_err(&[Token::I32(-2147483648)], &val_err(-2147483648, "i32", CnstMax::range()));
+    max_err(&[Token::I64(-2147483648)], &val_err(-2147483648, "i32", CnstMax::range()));
+    max_err(&[Token::I64(2147483648)], &val_err(2147483648_i64, "i32", CnstMax::range()));
 
     // From unsigned.
-    assert_min_err(&[Token::U32(2147483647)], &err(2147483647, "i32", CnstMin::range()));
-    assert_min_err(&[Token::U64(2147483647)], &err(2147483647, "i32", CnstMin::range()));
+    min_err(&[Token::U32(2147483647)], &val_err(2147483647, "i32", CnstMin::range()));
+    min_err(&[Token::U64(2147483647)], &val_err(2147483647, "i32", CnstMin::range()));
 
-    assert_max_err(&[Token::U32(2147483648)], &err(2147483648_u32, "i32", CnstMax::range()));
-    assert_max_err(&[Token::U64(2147483648)], &err(2147483648_u64, "i32", CnstMax::range()));
+    max_err(&[Token::U32(2147483648)], &val_err(2147483648_u32, "i32", CnstMax::range()));
+    max_err(&[Token::U64(2147483648)], &val_err(2147483648_u64, "i32", CnstMax::range()));
 }
 
 #[test]
-fn deserialize_error_cnst_i64() {
+fn unbounded_value_cnst_i64() {
     use constrained_int::i64::ConstrainedI64;
     type CnstMin = ConstrainedI64<-9223372036854775808, 9223372036854775806>;
     type CnstMax = ConstrainedI64<-9223372036854775807, 9223372036854775807>;
 
-    let assert_min_err = assert_de_tokens_error::<CnstMin>;
-    let assert_max_err = assert_de_tokens_error::<CnstMax>;
+    let min_err = assert_de_tokens_error::<CnstMin>;
+    let max_err = assert_de_tokens_error::<CnstMax>;
 
     // From signed.
-    assert_min_err(
+    min_err(
         &[Token::I64(9223372036854775807)],
-        &err(9223372036854775807_i64, "i64", CnstMin::range()),
+        &val_err(9223372036854775807_i64, "i64", CnstMin::range()),
     );
 
-    assert_max_err(
+    max_err(
         &[Token::I64(-9223372036854775808)],
-        &err(-9223372036854775808_i64, "i64", CnstMax::range()),
+        &val_err(-9223372036854775808_i64, "i64", CnstMax::range()),
     );
 
     // From unsigned.
-    assert_min_err(
+    min_err(
         &[Token::U64(9223372036854775807)],
-        &err(9223372036854775807_u64, "i64", CnstMin::range()),
+        &val_err(9223372036854775807_u64, "i64", CnstMin::range()),
     );
 
-    assert_max_err(
+    max_err(
         &[Token::U64(9223372036854775808)],
-        &err(9223372036854775808_u64, "i64", CnstMax::range()),
+        &val_err(9223372036854775808_u64, "i64", CnstMax::range()),
     );
 }
 
 #[test]
-fn deserialize_error_cnst_u8() {
+fn unbounded_value_cnst_u8() {
     use constrained_int::u8::ConstrainedU8;
     type CnstMin = ConstrainedU8<0, 254>;
     type CnstMax = ConstrainedU8<1, 255>;
 
-    let assert_min_err = assert_de_tokens_error::<CnstMin>;
-    let assert_max_err = assert_de_tokens_error::<CnstMax>;
+    let min_err = assert_de_tokens_error::<CnstMin>;
+    let max_err = assert_de_tokens_error::<CnstMax>;
 
     // From signed.
-    assert_min_err(&[Token::I8(-1)], &err(-1, "u8", CnstMin::range()));
-    assert_min_err(&[Token::I16(-1)], &err(-1, "u8", CnstMin::range()));
-    assert_min_err(&[Token::I16(255)], &err(255, "u8", CnstMin::range()));
-    assert_min_err(&[Token::I32(-1)], &err(-1, "u8", CnstMin::range()));
-    assert_min_err(&[Token::I32(255)], &err(255, "u8", CnstMin::range()));
-    assert_min_err(&[Token::I64(-1)], &err(-1, "u8", CnstMin::range()));
-    assert_min_err(&[Token::I64(255)], &err(255, "u8", CnstMin::range()));
+    min_err(&[Token::I8(-1)], &val_err(-1, "u8", CnstMin::range()));
+    min_err(&[Token::I16(-1)], &val_err(-1, "u8", CnstMin::range()));
+    min_err(&[Token::I16(255)], &val_err(255, "u8", CnstMin::range()));
+    min_err(&[Token::I32(-1)], &val_err(-1, "u8", CnstMin::range()));
+    min_err(&[Token::I32(255)], &val_err(255, "u8", CnstMin::range()));
+    min_err(&[Token::I64(-1)], &val_err(-1, "u8", CnstMin::range()));
+    min_err(&[Token::I64(255)], &val_err(255, "u8", CnstMin::range()));
 
-    assert_max_err(&[Token::I8(0)], &err(0, "u8", CnstMax::range()));
-    assert_max_err(&[Token::I16(0)], &err(0, "u8", CnstMax::range()));
-    assert_max_err(&[Token::I16(256)], &err(256, "u8", CnstMax::range()));
-    assert_max_err(&[Token::I32(0)], &err(0, "u8", CnstMax::range()));
-    assert_max_err(&[Token::I32(256)], &err(256, "u8", CnstMax::range()));
-    assert_max_err(&[Token::I32(0)], &err(0, "u8", CnstMax::range()));
-    assert_max_err(&[Token::I64(256)], &err(256, "u8", CnstMax::range()));
+    max_err(&[Token::I8(0)], &val_err(0, "u8", CnstMax::range()));
+    max_err(&[Token::I16(0)], &val_err(0, "u8", CnstMax::range()));
+    max_err(&[Token::I16(256)], &val_err(256, "u8", CnstMax::range()));
+    max_err(&[Token::I32(0)], &val_err(0, "u8", CnstMax::range()));
+    max_err(&[Token::I32(256)], &val_err(256, "u8", CnstMax::range()));
+    max_err(&[Token::I32(0)], &val_err(0, "u8", CnstMax::range()));
+    max_err(&[Token::I64(256)], &val_err(256, "u8", CnstMax::range()));
 
     // From unsigned.
-    assert_min_err(&[Token::U8(255)], &err(255, "u8", CnstMin::range()));
-    assert_min_err(&[Token::U16(255)], &err(255, "u8", CnstMin::range()));
-    assert_min_err(&[Token::U32(255)], &err(255, "u8", CnstMin::range()));
-    assert_min_err(&[Token::U64(255)], &err(255, "u8", CnstMin::range()));
+    min_err(&[Token::U8(255)], &val_err(255, "u8", CnstMin::range()));
+    min_err(&[Token::U16(255)], &val_err(255, "u8", CnstMin::range()));
+    min_err(&[Token::U32(255)], &val_err(255, "u8", CnstMin::range()));
+    min_err(&[Token::U64(255)], &val_err(255, "u8", CnstMin::range()));
 
-    assert_max_err(&[Token::U16(256)], &err(256, "u8", CnstMax::range()));
-    assert_max_err(&[Token::U32(256)], &err(256, "u8", CnstMax::range()));
-    assert_max_err(&[Token::U64(256)], &err(256, "u8", CnstMax::range()));
+    max_err(&[Token::U16(256)], &val_err(256, "u8", CnstMax::range()));
+    max_err(&[Token::U32(256)], &val_err(256, "u8", CnstMax::range()));
+    max_err(&[Token::U64(256)], &val_err(256, "u8", CnstMax::range()));
 }
 
 #[test]
-fn deserialize_error_cnst_u16() {
+fn unbounded_value_cnst_u16() {
     use constrained_int::u16::ConstrainedU16;
     type CnstMin = ConstrainedU16<0, 65534>;
     type CnstMax = ConstrainedU16<1, 65535>;
 
-    let assert_min_err = assert_de_tokens_error::<CnstMin>;
-    let assert_max_err = assert_de_tokens_error::<CnstMax>;
+    let min_err = assert_de_tokens_error::<CnstMin>;
+    let max_err = assert_de_tokens_error::<CnstMax>;
 
     // From signed.
-    assert_min_err(&[Token::I8(-1)], &err(-1, "u16", CnstMin::range()));
-    assert_min_err(&[Token::I16(-1)], &err(-1, "u16", CnstMin::range()));
-    assert_min_err(&[Token::I32(-1)], &err(-1, "u16", CnstMin::range()));
-    assert_min_err(&[Token::I32(65535)], &err(65535, "u16", CnstMin::range()));
-    assert_min_err(&[Token::I64(-1)], &err(-1, "u16", CnstMin::range()));
-    assert_min_err(&[Token::I64(65535)], &err(65535, "u16", CnstMin::range()));
+    min_err(&[Token::I8(-1)], &val_err(-1, "u16", CnstMin::range()));
+    min_err(&[Token::I16(-1)], &val_err(-1, "u16", CnstMin::range()));
+    min_err(&[Token::I32(-1)], &val_err(-1, "u16", CnstMin::range()));
+    min_err(&[Token::I32(65535)], &val_err(65535, "u16", CnstMin::range()));
+    min_err(&[Token::I64(-1)], &val_err(-1, "u16", CnstMin::range()));
+    min_err(&[Token::I64(65535)], &val_err(65535, "u16", CnstMin::range()));
 
-    assert_max_err(&[Token::I8(0)], &err(0, "u16", CnstMax::range()));
-    assert_max_err(&[Token::I16(0)], &err(0, "u16", CnstMax::range()));
-    assert_max_err(&[Token::I32(0)], &err(0, "u16", CnstMax::range()));
-    assert_max_err(&[Token::I32(65536)], &err(65536, "u16", CnstMax::range()));
-    assert_max_err(&[Token::I64(0)], &err(0, "u16", CnstMax::range()));
-    assert_max_err(&[Token::I64(65536)], &err(65536, "u16", CnstMax::range()));
+    max_err(&[Token::I8(0)], &val_err(0, "u16", CnstMax::range()));
+    max_err(&[Token::I16(0)], &val_err(0, "u16", CnstMax::range()));
+    max_err(&[Token::I32(0)], &val_err(0, "u16", CnstMax::range()));
+    max_err(&[Token::I32(65536)], &val_err(65536, "u16", CnstMax::range()));
+    max_err(&[Token::I64(0)], &val_err(0, "u16", CnstMax::range()));
+    max_err(&[Token::I64(65536)], &val_err(65536, "u16", CnstMax::range()));
 
     // From unsigned.
-    assert_min_err(&[Token::U16(65535)], &err(65535, "u16", CnstMin::range()));
-    assert_min_err(&[Token::U32(65535)], &err(65535, "u16", CnstMin::range()));
-    assert_min_err(&[Token::U64(65535)], &err(65535, "u16", CnstMin::range()));
+    min_err(&[Token::U16(65535)], &val_err(65535, "u16", CnstMin::range()));
+    min_err(&[Token::U32(65535)], &val_err(65535, "u16", CnstMin::range()));
+    min_err(&[Token::U64(65535)], &val_err(65535, "u16", CnstMin::range()));
 
-    assert_max_err(&[Token::U32(65536)], &err(65536, "u16", CnstMax::range()));
-    assert_max_err(&[Token::U64(65536)], &err(65536, "u16", CnstMax::range()));
+    max_err(&[Token::U32(65536)], &val_err(65536, "u16", CnstMax::range()));
+    max_err(&[Token::U64(65536)], &val_err(65536, "u16", CnstMax::range()));
 }
 
 #[test]
-fn deserialize_error_cnst_u32() {
+fn unbounded_value_cnst_u32() {
     use constrained_int::u32::ConstrainedU32;
     type CnstMin = ConstrainedU32<0, 4294967294>;
     type CnstMax = ConstrainedU32<1, 4294967295>;
 
-    let assert_min_err = assert_de_tokens_error::<CnstMin>;
-    let assert_max_err = assert_de_tokens_error::<CnstMax>;
+    let min_err = assert_de_tokens_error::<CnstMin>;
+    let max_err = assert_de_tokens_error::<CnstMax>;
 
     // From signed.
-    assert_min_err(&[Token::I8(-1)], &err(-1, "u32", CnstMin::range()));
-    assert_min_err(&[Token::I16(-1)], &err(-1, "u32", CnstMin::range()));
-    assert_min_err(&[Token::I32(-1)], &err(-1, "u32", CnstMin::range()));
-    assert_min_err(&[Token::I64(-1)], &err(-1, "u32", CnstMin::range()));
-    assert_min_err(&[Token::I64(4294967295)], &err(4294967295_i64, "u32", CnstMin::range()));
+    min_err(&[Token::I8(-1)], &val_err(-1, "u32", CnstMin::range()));
+    min_err(&[Token::I16(-1)], &val_err(-1, "u32", CnstMin::range()));
+    min_err(&[Token::I32(-1)], &val_err(-1, "u32", CnstMin::range()));
+    min_err(&[Token::I64(-1)], &val_err(-1, "u32", CnstMin::range()));
+    min_err(&[Token::I64(4294967295)], &val_err(4294967295_i64, "u32", CnstMin::range()));
 
-    assert_max_err(&[Token::I8(0)], &err(0, "u32", CnstMax::range()));
-    assert_max_err(&[Token::I16(0)], &err(0, "u32", CnstMax::range()));
-    assert_max_err(&[Token::I32(0)], &err(0, "u32", CnstMax::range()));
-    assert_max_err(&[Token::I64(0)], &err(0, "u32", CnstMax::range()));
-    assert_max_err(&[Token::I64(4294967296)], &err(4294967296_i64, "u32", CnstMax::range()));
+    max_err(&[Token::I8(0)], &val_err(0, "u32", CnstMax::range()));
+    max_err(&[Token::I16(0)], &val_err(0, "u32", CnstMax::range()));
+    max_err(&[Token::I32(0)], &val_err(0, "u32", CnstMax::range()));
+    max_err(&[Token::I64(0)], &val_err(0, "u32", CnstMax::range()));
+    max_err(&[Token::I64(4294967296)], &val_err(4294967296_i64, "u32", CnstMax::range()));
 
     // From unsigned.
-    assert_min_err(&[Token::U32(4294967295)], &err(4294967295_u32, "u32", CnstMin::range()));
-    assert_min_err(&[Token::U64(4294967295)], &err(4294967295_u64, "u32", CnstMin::range()));
+    min_err(&[Token::U32(4294967295)], &val_err(4294967295_u32, "u32", CnstMin::range()));
+    min_err(&[Token::U64(4294967295)], &val_err(4294967295_u64, "u32", CnstMin::range()));
 
-    assert_max_err(&[Token::U64(4294967296)], &err(4294967296_u64, "u32", CnstMax::range()));
+    max_err(&[Token::U64(4294967296)], &val_err(4294967296_u64, "u32", CnstMax::range()));
 }
 
 #[test]
-fn deserialize_error_cnst_u64() {
+fn unbounded_value_cnst_u64() {
     use constrained_int::u64::ConstrainedU64;
     type CnstMin = ConstrainedU64<0, 18446744073709551614>;
     type CnstMax = ConstrainedU64<1, 18446744073709551615>;
 
-    let assert_min_err = assert_de_tokens_error::<CnstMin>;
-    let assert_max_err = assert_de_tokens_error::<CnstMax>;
+    let min_err = assert_de_tokens_error::<CnstMin>;
+    let max_err = assert_de_tokens_error::<CnstMax>;
 
     // From signed.
-    assert_min_err(&[Token::I8(-1)], &err(-1, "u64", CnstMin::range()));
-    assert_min_err(&[Token::I16(-1)], &err(-1, "u64", CnstMin::range()));
-    assert_min_err(&[Token::I32(-1)], &err(-1, "u64", CnstMin::range()));
-    assert_min_err(&[Token::I64(-1)], &err(-1, "u64", CnstMin::range()));
-    assert_min_err(&[Token::I64(-1)], &err(-1, "u64", CnstMin::range()));
+    min_err(&[Token::I8(-1)], &val_err(-1, "u64", CnstMin::range()));
+    min_err(&[Token::I16(-1)], &val_err(-1, "u64", CnstMin::range()));
+    min_err(&[Token::I32(-1)], &val_err(-1, "u64", CnstMin::range()));
+    min_err(&[Token::I64(-1)], &val_err(-1, "u64", CnstMin::range()));
+    min_err(&[Token::I64(-1)], &val_err(-1, "u64", CnstMin::range()));
 
-    assert_max_err(&[Token::I8(0)], &err(0, "u64", CnstMax::range()));
-    assert_max_err(&[Token::I16(0)], &err(0, "u64", CnstMax::range()));
-    assert_max_err(&[Token::I32(0)], &err(0, "u64", CnstMax::range()));
-    assert_max_err(&[Token::I64(0)], &err(0, "u64", CnstMax::range()));
-    assert_max_err(&[Token::I64(0)], &err(0, "u64", CnstMax::range()));
+    max_err(&[Token::I8(0)], &val_err(0, "u64", CnstMax::range()));
+    max_err(&[Token::I16(0)], &val_err(0, "u64", CnstMax::range()));
+    max_err(&[Token::I32(0)], &val_err(0, "u64", CnstMax::range()));
+    max_err(&[Token::I64(0)], &val_err(0, "u64", CnstMax::range()));
+    max_err(&[Token::I64(0)], &val_err(0, "u64", CnstMax::range()));
+}
+
+macro_rules! range_err {
+    ($Cnst:ident) => {
+        concat!(
+            // serde's invalid_type.
+            "invalid type: ",
+            // user defined.
+            stringify!($Cnst), "<MIN, MAX, DEF>",
+            // serde's expecting.
+            ", expected ",
+            // user defined.
+            "MIN, MAX and DEF to comply with construction constraints"
+        )
+    };
+}
+
+macro_rules! impl_invalid_range_test_for {
+    ($({ $Num:ident, $num_mod:ident, $Cnst:ident, $test:ident }),+ $(,)*) => {$(
+        #[test]
+        fn $test() {
+            use constrained_int::$num_mod::$Cnst;
+            type MinMax = $Cnst<{ $Num::MIN }, { $Num::MAX }>;
+            type MinEqMax = $Cnst<0, 0>;
+            type MinGtMax = $Cnst<1, 0>;
+            type DefOut = $Cnst<0, 1 , 2>;
+
+            let minmax_err = assert_de_tokens_error::<MinMax>;
+            let mineqmax_err = assert_de_tokens_error::<MinEqMax>;
+            let mingtmax_err = assert_de_tokens_error::<MinGtMax>;
+            let defout_err = assert_de_tokens_error::<DefOut>;
+
+            minmax_err(&[Token::I8(0)], range_err!($Cnst));
+            minmax_err(&[Token::I16(0)], range_err!($Cnst));
+            minmax_err(&[Token::I32(0)], range_err!($Cnst));
+            minmax_err(&[Token::I64(0)], range_err!($Cnst));
+            minmax_err(&[Token::U8(0)], range_err!($Cnst));
+            minmax_err(&[Token::U16(0)], range_err!($Cnst));
+            minmax_err(&[Token::U32(0)], range_err!($Cnst));
+            minmax_err(&[Token::U64(0)], range_err!($Cnst));
+
+            mineqmax_err(&[Token::I8(0)], range_err!($Cnst));
+            mineqmax_err(&[Token::I16(0)], range_err!($Cnst));
+            mineqmax_err(&[Token::I32(0)], range_err!($Cnst));
+            mineqmax_err(&[Token::I64(0)], range_err!($Cnst));
+            mineqmax_err(&[Token::U8(0)], range_err!($Cnst));
+            mineqmax_err(&[Token::U16(0)], range_err!($Cnst));
+            mineqmax_err(&[Token::U32(0)], range_err!($Cnst));
+            mineqmax_err(&[Token::U64(0)], range_err!($Cnst));
+
+            mingtmax_err(&[Token::I8(0)], range_err!($Cnst));
+            mingtmax_err(&[Token::I16(0)], range_err!($Cnst));
+            mingtmax_err(&[Token::I32(0)], range_err!($Cnst));
+            mingtmax_err(&[Token::I64(0)], range_err!($Cnst));
+            mingtmax_err(&[Token::U8(0)], range_err!($Cnst));
+            mingtmax_err(&[Token::U16(0)], range_err!($Cnst));
+            mingtmax_err(&[Token::U32(0)], range_err!($Cnst));
+            mingtmax_err(&[Token::U64(0)], range_err!($Cnst));
+
+            defout_err(&[Token::I8(0)], range_err!($Cnst));
+            defout_err(&[Token::I16(0)], range_err!($Cnst));
+            defout_err(&[Token::I32(0)], range_err!($Cnst));
+            defout_err(&[Token::I64(0)], range_err!($Cnst));
+            defout_err(&[Token::U8(0)], range_err!($Cnst));
+            defout_err(&[Token::U16(0)], range_err!($Cnst));
+            defout_err(&[Token::U32(0)], range_err!($Cnst));
+            defout_err(&[Token::U64(0)], range_err!($Cnst));
+        }
+    )+};
+}
+
+impl_invalid_range_test_for! {
+    { u8, u8, ConstrainedU8, invalid_range_cnst_u8 },
+    { u16, u16, ConstrainedU16, invalid_range_cnst_u16 },
+    { u32, u32, ConstrainedU32, invalid_range_cnst_u32 },
+    { u64, u64, ConstrainedU64, invalid_range_cnst_u64 },
+    { u128, u128, ConstrainedU128, invalid_range_cnst_u128 },
+    { usize, usize, ConstrainedUsize, invalid_range_cnst_usize },
+
+    { i8, i8, ConstrainedI8, invalid_range_cnst_i8 },
+    { i16, i16, ConstrainedI16, invalid_range_cnst_i16 },
+    { i32, i32, ConstrainedI32, invalid_range_cnst_i32 },
+    { i64, i64, ConstrainedI64, invalid_range_cnst_i64 },
+    { i128, i128, ConstrainedI128, invalid_range_cnst_i128 },
+    { isize, isize, ConstrainedIsize, invalid_range_cnst_isize },
 }

--- a/tests/deserialize_error.rs
+++ b/tests/deserialize_error.rs
@@ -15,6 +15,7 @@ where
 }
 
 #[test]
+#[cfg(any(cnst8bitonly, not(cnst8bitonly)))]
 fn unbounded_value_cnst_i8() {
     use constrained_int::i8::ConstrainedI8;
     type CnstMin = ConstrainedI8<-128, 126>;
@@ -53,6 +54,7 @@ fn unbounded_value_cnst_i8() {
 }
 
 #[test]
+#[cfg(not(cnst8bitonly))]
 fn unbounded_value_cnst_i16() {
     use constrained_int::i16::ConstrainedI16;
     type CnstMin = ConstrainedI16<-32768, 32766>;
@@ -85,6 +87,7 @@ fn unbounded_value_cnst_i16() {
 }
 
 #[test]
+#[cfg(not(cnst8bitonly))]
 fn unbounded_value_cnst_i32() {
     use constrained_int::i32::ConstrainedI32;
     type CnstMin = ConstrainedI32<-2147483648, 2147483646>;
@@ -111,6 +114,7 @@ fn unbounded_value_cnst_i32() {
 }
 
 #[test]
+#[cfg(not(cnst8bitonly))]
 fn unbounded_value_cnst_i64() {
     use constrained_int::i64::ConstrainedI64;
     type CnstMin = ConstrainedI64<-9223372036854775808, 9223372036854775806>;
@@ -143,6 +147,7 @@ fn unbounded_value_cnst_i64() {
 }
 
 #[test]
+#[cfg(any(cnst8bitonly, not(cnst8bitonly)))]
 fn unbounded_value_cnst_u8() {
     use constrained_int::u8::ConstrainedU8;
     type CnstMin = ConstrainedU8<0, 254>;
@@ -180,6 +185,7 @@ fn unbounded_value_cnst_u8() {
 }
 
 #[test]
+#[cfg(not(cnst8bitonly))]
 fn unbounded_value_cnst_u16() {
     use constrained_int::u16::ConstrainedU16;
     type CnstMin = ConstrainedU16<0, 65534>;
@@ -213,6 +219,7 @@ fn unbounded_value_cnst_u16() {
 }
 
 #[test]
+#[cfg(not(cnst8bitonly))]
 fn unbounded_value_cnst_u32() {
     use constrained_int::u32::ConstrainedU32;
     type CnstMin = ConstrainedU32<0, 4294967294>;
@@ -242,6 +249,7 @@ fn unbounded_value_cnst_u32() {
 }
 
 #[test]
+#[cfg(not(cnst8bitonly))]
 fn unbounded_value_cnst_u64() {
     use constrained_int::u64::ConstrainedU64;
     type CnstMin = ConstrainedU64<0, 18446744073709551614>;
@@ -334,15 +342,24 @@ macro_rules! impl_invalid_range_test_for {
     )+};
 }
 
+#[cfg(any(cnst8bitonly, not(cnst8bitonly)))]
 impl_invalid_range_test_for! {
     { u8, u8, ConstrainedU8, invalid_range_cnst_u8 },
+}
+#[cfg(not(cnst8bitonly))]
+impl_invalid_range_test_for! {
     { u16, u16, ConstrainedU16, invalid_range_cnst_u16 },
     { u32, u32, ConstrainedU32, invalid_range_cnst_u32 },
     { u64, u64, ConstrainedU64, invalid_range_cnst_u64 },
     { u128, u128, ConstrainedU128, invalid_range_cnst_u128 },
     { usize, usize, ConstrainedUsize, invalid_range_cnst_usize },
-
+}
+#[cfg(any(cnst8bitonly, not(cnst8bitonly)))]
+impl_invalid_range_test_for! {
     { i8, i8, ConstrainedI8, invalid_range_cnst_i8 },
+}
+#[cfg(not(cnst8bitonly))]
+impl_invalid_range_test_for! {
     { i16, i16, ConstrainedI16, invalid_range_cnst_i16 },
     { i32, i32, ConstrainedI32, invalid_range_cnst_i32 },
     { i64, i64, ConstrainedI64, invalid_range_cnst_i64 },


### PR DESCRIPTION
Implements serde's Serialize and Deserialize traits for all Constrained types. This is a optional dependency, it can be enabled with the `serde` feature. The `serde` feature is compatible with `no_std` environments.