### PR TITLE
Rework constraints guard

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -148,7 +148,7 @@ jobs:
       - name: Run cargo check
         uses: actions-rs/cargo@v1
         with:
-          command: check
+          command: build
           args: >
             ${{ matrix.features }}
             --target thumbv7m-none-eabi
@@ -158,7 +158,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       CARGO_PUBLIC_API_VERSION: 0.24.0
-      NIGHTLY_COMPATIBLE: nightly-2022-08-15
+      NIGHTLY_COMPATIBLE: nightly-2022-09-28
 
     steps:
       - name: Install nightly toolchain

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,6 @@ std = []
 serde = ["dep:serde"]
 
 [dependencies]
-const_guards = { version = "0.1.3" }
 serde = { version = "1", default-features = false, optional = true }
 
 [dev-dependencies]

--- a/README.md
+++ b/README.md
@@ -17,10 +17,10 @@ value assignment, they also implement wrapping, saturating, overflowing
 and checked arithmetic operations for the range boundaries. See each desired
 type documentation for more information.
 
-The `constrained_int` crate relies on the [const_guards] crate to define compile
-time constraints, which itself uses the incomplete [generic_const_exprs]
-feature. Therefore, this crate can only be compiled with nightly and, more
-importantly, must be considered as an **experimental** crate only.
+The `constrained_int` crate relies on the incomplete [generic_const_exprs]
+feature to define compile time constraints for const generic parameters.
+Therefore, this crate can only be compiled with nightly and, more importantly,
+must be considered as an **experimental** crate only.
 
 This crate is `no_std` by default. See features section for more information.
 
@@ -123,7 +123,6 @@ It is recommended to always use [cargo-crev] to verify the trustworthiness of
 each of your dependencies, including this one.
 
 [//]: # "general links"
-[const_guards]: https://docs.rs/const_guards/latest/const_guards/
 [generic_const_exprs]: https://github.com/rust-lang/rust/issues/76560
 [serde]: https://serde.rs/
 [cargo-crev]: https://github.com/crev-dev/cargo-crev

--- a/src/deserialize/macros.rs
+++ b/src/deserialize/macros.rs
@@ -63,7 +63,7 @@ macro_rules! num_as_self_uint {
         fn $visit<E: DesError>(self, v: $UnsInt) -> Result<Self::Value, E> {
             self.guard_construction()?;
             let err = |_| E::invalid_value(Unexpected::Unsigned(v as u64), &self);
-            Self::Value::__new(v as $Inner).map_err(err)
+            Self::Value::new_unguarded(v as $Inner).map_err(err)
         }
     };
 }
@@ -74,7 +74,7 @@ macro_rules! num_as_self_int {
         fn $visit<E: DesError>(self, v: $SigInt) -> Result<Self::Value, E> {
             self.guard_construction()?;
             let err = |_| E::invalid_value(Unexpected::Signed(v as i64), &self);
-            Self::Value::__new(v as $Inner).map_err(err)
+            Self::Value::new_unguarded(v as $Inner).map_err(err)
         }
     };
 }
@@ -87,7 +87,7 @@ macro_rules! uint_to_self {
             self.guard_construction()?;
 
             if v as u64 <= <$Inner>::MAX as u64 {
-                if let Ok(value) = Self::Value::__new(v as $Inner) {
+                if let Ok(value) = Self::Value::new_unguarded(v as $Inner) {
                     return Ok(value);
                 }
             }
@@ -104,7 +104,7 @@ macro_rules! int_to_int {
             self.guard_construction()?;
 
             if <$SigInner>::MIN as i64 <= v as i64 && v as i64 <= <$SigInner>::MAX as i64 {
-                if let Ok(value) = Self::Value::__new(v as $SigInner) {
+                if let Ok(value) = Self::Value::new_unguarded(v as $SigInner) {
                     return Ok(value);
                 }
             }
@@ -121,7 +121,7 @@ macro_rules! int_to_uint {
             self.guard_construction()?;
 
             if 0 <= v && v as u64 <= <$UnsInner>::MAX as u64 {
-                if let Ok(value) = Self::Value::__new(v as $UnsInner) {
+                if let Ok(value) = Self::Value::new_unguarded(v as $UnsInner) {
                     return Ok(value);
                 }
             }
@@ -138,7 +138,7 @@ macro_rules! num_128 {
             self.guard_construction()?;
 
             if v as i128 >= <$Inner>::MIN as i128 && v as u128 <= <$Inner>::MAX as u128 {
-                if let Ok(value) = Self::Value::__new(v as $Inner) {
+                if let Ok(value) = Self::Value::new_unguarded(v as $Inner) {
                     return Ok(value);
                 }
             }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,10 +8,10 @@
 //! and checked arithmetic operations for the range boundaries. See each desired
 //! type documentation for more information.
 //!
-//! The `constrained_int` crate relies on the [`const_guards`] crate to define
-//! compile time constraints, which itself uses the incomplete [`generic_const_exprs`]
-//! feature. Therefore, this crate can only be compiled with nightly and, more
-//! importantly, must be considered as an **experimental** crate only.
+//! The `constrained_int` crate relies on the incomplete [`generic_const_exprs`]
+//! feature to define compile time constraints. Therefore, this crate can only
+//! be compiled with nightly and, more importantly, must be considered as an
+//! **experimental** crate only.
 //!
 //! This crate is `no_std` by default. See features section for more information.
 //!
@@ -86,7 +86,6 @@
 // The `std` feature will import `std` as a dependency.
 #![cfg_attr(not(feature = "std"), no_std)]
 //
-// The `const_guards` dependency relies on `generic_const_exprs`.
 // Tracking issue for `generic_const_exprs`:
 // https://github.com/rust-lang/rust/issues/76560
 #![allow(incomplete_features)]
@@ -113,6 +112,7 @@
 // - `constrained_uint_def_impl!`.
 // - `constrained_int_def_impl!`.
 // - `forward_ref_binop!`.
+// - `forward_ref_op_assign!`.
 #[macro_use]
 mod macros;
 
@@ -121,6 +121,9 @@ mod macros;
 // - `forward_ref_op_assign!`.
 mod num;
 pub use num::{Saturating, Wrapping};
+
+mod sealed;
+use sealed::{Constraints, Guard};
 
 #[cfg(feature = "serde")]
 #[doc(cfg(feature = "serde"))]

--- a/src/sealed.rs
+++ b/src/sealed.rs
@@ -1,0 +1,6 @@
+#[doc(hidden)]
+pub struct Constraints<const T: bool>;
+
+#[doc(hidden)]
+pub trait Guard {}
+impl Guard for Constraints<true> {}


### PR DESCRIPTION
Drop `const_guards` dependency and implement the guards directly. This will lift some limitations on public visibility.