### PR TITLE
Add construction clauses to Deserialize impl

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,10 +99,10 @@ If users already are importing the standard library on their crate, enabling
 ### serde
 
 The `serde` feature implements [serde]'s `Serialize` and `Deserialize` traits
-for `Wrapping`, `Saturating` and all `Constrained` types. Note that construction
-constraints for const generic parameters are checked at runtime when values are
-deserialized to any of `Constrained` types. See each desired type documentation
-for more information about these constraints.
+for `Wrapping`, `Saturating` and all `Constrained` types. Note that `Constrained`
+type's construction constraints are also evaluated for the `Deserialize`
+implementation. See each desired type documentation for more information about
+these constraints.
 
 ## License
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -71,11 +71,11 @@
 //!
 //! ### serde
 //!
-//! The `serde` feature implements [`serde`]'s `Serialize` and `Deserialize` traits
-//! for `Wrapping`, `Saturating` and all `Constrained` types. Note that construction
-//! constraints for the const generic parameters are checked at runtime when values
-//! are deserialized to any of the `Constrained` types. See each desired type
-//! documentation for more information about these constraints.
+//! The `serde` feature implements [serde]'s `Serialize` and `Deserialize` traits
+//! for `Wrapping`, `Saturating` and all `Constrained` types. Note that `Constrained`
+//! type's construction constraints are also evaluated for the `Deserialize`
+//! implementation. See each desired type documentation for more information about
+//! these constraints.
 //!
 //! [`generic_const_exprs`]: https://github.com/rust-lang/rust/issues/76560
 //! [`serde`]: https://docs.rs/serde/latest/serde/

--- a/src/macros/common.rs
+++ b/src/macros/common.rs
@@ -361,7 +361,7 @@ macro_rules! constrained_def_impl {
             }
 
             /// Unguarded private `new` constructor.
-            pub(crate) const fn new_unguarded(value: $Int) -> Result<Self, $Err<MIN, MAX>> {
+            const fn new_unguarded(value: $Int) -> Result<Self, $Err<MIN, MAX>> {
                 // Can't use `?` operator on const fn yet:
                 // https://github.com/rust-lang/rust/issues/74935.
                 match Self::in_range(value) {

--- a/tests/deserialize.rs
+++ b/tests/deserialize.rs
@@ -1,3 +1,6 @@
+#![allow(incomplete_features)]
+#![feature(generic_const_exprs)]
+
 use serde_test::{assert_de_tokens, Token};
 
 #[test]

--- a/tests/deserialize_error.rs
+++ b/tests/deserialize_error.rs
@@ -1,3 +1,6 @@
+#![allow(incomplete_features)]
+#![feature(generic_const_exprs)]
+
 use serde_test::{assert_de_tokens_error, Token};
 use std::fmt::{Display, Write};
 use std::ops::RangeInclusive;
@@ -262,94 +265,6 @@ fn unbounded_value_cnst_u64() {
     max_err(&[Token::I32(0)], &val_err(0, "u64", CnstMax::range()));
     max_err(&[Token::I64(0)], &val_err(0, "u64", CnstMax::range()));
     max_err(&[Token::I64(0)], &val_err(0, "u64", CnstMax::range()));
-}
-
-macro_rules! range_err {
-    ($Cnst:ident) => {
-        concat!(
-            // serde's invalid_type.
-            "invalid type: ",
-            // user defined.
-            stringify!($Cnst),
-            "<MIN, MAX, DEF>",
-            // serde's expecting.
-            ", expected ",
-            // user defined.
-            "MIN, MAX and DEF to comply with construction constraints"
-        )
-    };
-}
-
-macro_rules! impl_invalid_range_test_for {
-    ($({ $Num:ident, $num_mod:ident, $Cnst:ident, $test:ident }),+ $(,)*) => {$(
-        #[test]
-        fn $test() {
-            use constrained_int::$num_mod::$Cnst;
-            type MinMax = $Cnst<{ $Num::MIN }, { $Num::MAX }>;
-            type MinEqMax = $Cnst<0, 0>;
-            type MinGtMax = $Cnst<1, 0>;
-            type DefOut = $Cnst<0, 1 , 2>;
-
-            let minmax_err = assert_de_tokens_error::<MinMax>;
-            let mineqmax_err = assert_de_tokens_error::<MinEqMax>;
-            let mingtmax_err = assert_de_tokens_error::<MinGtMax>;
-            let defout_err = assert_de_tokens_error::<DefOut>;
-
-            minmax_err(&[Token::I8(0)], range_err!($Cnst));
-            minmax_err(&[Token::I16(0)], range_err!($Cnst));
-            minmax_err(&[Token::I32(0)], range_err!($Cnst));
-            minmax_err(&[Token::I64(0)], range_err!($Cnst));
-            minmax_err(&[Token::U8(0)], range_err!($Cnst));
-            minmax_err(&[Token::U16(0)], range_err!($Cnst));
-            minmax_err(&[Token::U32(0)], range_err!($Cnst));
-            minmax_err(&[Token::U64(0)], range_err!($Cnst));
-
-            mineqmax_err(&[Token::I8(0)], range_err!($Cnst));
-            mineqmax_err(&[Token::I16(0)], range_err!($Cnst));
-            mineqmax_err(&[Token::I32(0)], range_err!($Cnst));
-            mineqmax_err(&[Token::I64(0)], range_err!($Cnst));
-            mineqmax_err(&[Token::U8(0)], range_err!($Cnst));
-            mineqmax_err(&[Token::U16(0)], range_err!($Cnst));
-            mineqmax_err(&[Token::U32(0)], range_err!($Cnst));
-            mineqmax_err(&[Token::U64(0)], range_err!($Cnst));
-
-            mingtmax_err(&[Token::I8(0)], range_err!($Cnst));
-            mingtmax_err(&[Token::I16(0)], range_err!($Cnst));
-            mingtmax_err(&[Token::I32(0)], range_err!($Cnst));
-            mingtmax_err(&[Token::I64(0)], range_err!($Cnst));
-            mingtmax_err(&[Token::U8(0)], range_err!($Cnst));
-            mingtmax_err(&[Token::U16(0)], range_err!($Cnst));
-            mingtmax_err(&[Token::U32(0)], range_err!($Cnst));
-            mingtmax_err(&[Token::U64(0)], range_err!($Cnst));
-
-            defout_err(&[Token::I8(0)], range_err!($Cnst));
-            defout_err(&[Token::I16(0)], range_err!($Cnst));
-            defout_err(&[Token::I32(0)], range_err!($Cnst));
-            defout_err(&[Token::I64(0)], range_err!($Cnst));
-            defout_err(&[Token::U8(0)], range_err!($Cnst));
-            defout_err(&[Token::U16(0)], range_err!($Cnst));
-            defout_err(&[Token::U32(0)], range_err!($Cnst));
-            defout_err(&[Token::U64(0)], range_err!($Cnst));
-        }
-    )+};
-}
-
-impl_invalid_range_test_for! {
-    { u8, u8, ConstrainedU8, invalid_range_cnst_u8 },
-    { u16, u16, ConstrainedU16, invalid_range_cnst_u16 },
-    { u32, u32, ConstrainedU32, invalid_range_cnst_u32 },
-    { u64, u64, ConstrainedU64, invalid_range_cnst_u64 },
-    { u128, u128, ConstrainedU128, invalid_range_cnst_u128 },
-    { usize, usize, ConstrainedUsize, invalid_range_cnst_usize },
-}
-
-impl_invalid_range_test_for! {
-    { i8, i8, ConstrainedI8, invalid_range_cnst_i8 },
-    { i16, i16, ConstrainedI16, invalid_range_cnst_i16 },
-    { i32, i32, ConstrainedI32, invalid_range_cnst_i32 },
-    { i64, i64, ConstrainedI64, invalid_range_cnst_i64 },
-    { i128, i128, ConstrainedI128, invalid_range_cnst_i128 },
-    { isize, isize, ConstrainedIsize, invalid_range_cnst_isize },
 }
 
 #[test]


### PR DESCRIPTION
`Constrained` construction constraints are now also required for serde's `Deserialize` implementation. This means that runtime construction checks are no longer necessary when deserializing a `Constrained` type. This add a new where clause to `Deserialize` impl to evaluate the constraints, which means this is a breaking change.