### PR TITLE
Implement core::iter::Sum for Wrapping

### DIFF
--- a/src/macros/common.rs
+++ b/src/macros/common.rs
@@ -345,6 +345,7 @@ macro_rules! constrained_def_impl {
             }
         }
 
+        // Unguarded functions.
         impl<const MIN: $Int, const MAX: $Int, const DEF: $Int> $Ty<MIN, MAX, DEF> {
             /// Checks if value is within the defined range, assuming that `MAX` < `MIN`
             /// is an impossible state.
@@ -436,6 +437,12 @@ macro_rules! constrained_def_impl {
             #[inline(always)]
             pub const fn get(&self) -> $Int {
                 self.0
+            }
+
+            /// Constructs `Self` with the inner value set to 0, regardless of the range definition.
+            /// Usefull for sums as it returns the additive neutral value for `Self`.
+            pub(crate) const fn zero() -> Self {
+                Self(0)
             }
         }
 

--- a/src/num/macros/wrapping.rs
+++ b/src/num/macros/wrapping.rs
@@ -6,6 +6,44 @@ macro_rules! wrapping_common {
             { Add(add), AddAssign(add_assign) => wrapping_add },
             { Sub(sub), SubAssign(sub_assign) => wrapping_sub },
         }
+
+        impl<const MIN: $Int, const MAX: $Int, const DEF: $Int> core::iter::Sum
+            for Wrapping<$Cnst<MIN, MAX, DEF>>
+        {
+            fn sum<I: Iterator<Item = Self>>(iter: I) -> Self {
+                iter.fold(Wrapping($Cnst::zero()), |acc, elem| acc + elem)
+            }
+        }
+
+        impl<'a, const MIN: $Int, const MAX: $Int, const DEF: $Int>
+            core::iter::Sum<&'a Wrapping<$Cnst<MIN, MAX, DEF>>> for Wrapping<$Cnst<MIN, MAX, DEF>>
+        {
+            fn sum<I: Iterator<Item = &'a Wrapping<$Cnst<MIN, MAX, DEF>>>>(iter: I) -> Self {
+                iter.fold(Wrapping($Cnst::zero()), |acc, elem| acc + *elem)
+            }
+        }
+
+        #[cfg(test)]
+        mod test_common {
+            use super::$Cnst;
+            use super::Wrapping;
+
+            type WrappingSumTest = Wrapping<$Cnst<0, 1>>;
+            const WRAPPING_SUM_TEST: [WrappingSumTest; 2] =
+                [Wrapping($Cnst::new_max()), Wrapping($Cnst::new_max())];
+
+            #[test]
+            fn sum_impl_for_wrapping() {
+                let sum: WrappingSumTest = WRAPPING_SUM_TEST.into_iter().sum();
+                assert_eq!(sum.0.get(), 0);
+            }
+
+            #[test]
+            fn sum_impl_for_wrapping_ref() {
+                let sum: WrappingSumTest = WRAPPING_SUM_TEST.iter().sum();
+                assert_eq!(sum.0.get(), 0);
+            }
+        }
     };
 }
 


### PR DESCRIPTION
Add core::iter::Sum trait implementation for `Wrapping<T>` when T is one of the `Constrained` types. 